### PR TITLE
Minor updates and fixes for SRA workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
             "--nf_core_pipeline rnaseq",
             "--ena_metadata_fields run_accession,experiment_accession,library_layout,fastq_ftp,fastq_md5 --sample_mapping_fields run_accession,library_layout",
             --skip_fastq_download,
+            --force_sratools_download
           ]
     steps:
       - name: Check out pipeline code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * SRA identifiers not available for direct download via the ENA FTP will now be downloaded via [`sra-tools`](https://github.com/ncbi/sra-tools).
 * Correctly handle errors from SRA identifiers that do **not** return metadata, for example, due to being private.
 * Retry an error in prefetch via bash script in order to allow it to resume interrupted downloads.
-* Rename output FastQ files using `{EXP_ACC}_{RUN_ACC}_T1*fastq.gz` convention for run id provenance
+* Name output FastQ files by `{EXP_ACC}_{RUN_ACC}*fastq.gz` instead of `{EXP_ACC}_{T*}*fastq.gz` for run id provenance
 * [[#46](https://github.com/nf-core/fetchngs/issues/46)] - Bug in sra_ids_to_runinfo.py
 * Added support for [DDBJ ids](https://www.ddbj.nig.ac.jp/index-e.html). See examples below:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,14 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [[1.4](https://github.com/nf-core/fetchngs/releases/tag/1.4)] - 2021-10-25
+## [[1.4](https://github.com/nf-core/fetchngs/releases/tag/1.4)] - 2021-11-09
 
 ### Enhancements & fixes
 
 * Convert pipeline to updated Nextflow DSL2 syntax for future adoption across nf-core
 * Added a workflow to download FastQ files and to create samplesheets for ids from the [Synapse platform](https://www.synapse.org/) hosted by [Sage Bionetworks](https://sagebionetworks.org/).
 * SRA identifiers not available for direct download via the ENA FTP will now be downloaded via [`sra-tools`](https://github.com/ncbi/sra-tools).
+* Added `--force_sratools_download` parameter to preferentially download all FastQ files via `sra-tools` instead of ENA FTP.
 * Correctly handle errors from SRA identifiers that do **not** return metadata, for example, due to being private.
 * Retry an error in prefetch via bash script in order to allow it to resume interrupted downloads.
 * Name output FastQ files by `{EXP_ACC}_{RUN_ACC}*fastq.gz` instead of `{EXP_ACC}_{T*}*fastq.gz` for run id provenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Convert pipeline to updated Nextflow DSL2 syntax for future adoption across nf-core
 * Added a workflow to download FastQ files and to create samplesheets for ids from the [Synapse platform](https://www.synapse.org/) hosted by [Sage Bionetworks](https://sagebionetworks.org/).
-* SRA identifiers not available for direct download via the ENA FTP will now be downloaded via sra-tools.
+* SRA identifiers not available for direct download via the ENA FTP will now be downloaded via [`sra-tools`](https://github.com/ncbi/sra-tools).
 * Correctly handle errors from SRA identifiers that do **not** return metadata, for example, due to being private.
 * Retry an error in prefetch via bash script in order to allow it to resume interrupted downloads.
 * [[#46](https://github.com/nf-core/fetchngs/issues/46)] - Bug in sra_ids_to_runinfo.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * SRA identifiers not available for direct download via the ENA FTP will now be downloaded via [`sra-tools`](https://github.com/ncbi/sra-tools).
 * Correctly handle errors from SRA identifiers that do **not** return metadata, for example, due to being private.
 * Retry an error in prefetch via bash script in order to allow it to resume interrupted downloads.
+* Rename output FastQ files using `{EXP_ACC}_{RUN_ACC}_T1*fastq.gz` convention for run id provenance
 * [[#46](https://github.com/nf-core/fetchngs/issues/46)] - Bug in sra_ids_to_runinfo.py
 * Added support for [DDBJ ids](https://www.ddbj.nig.ac.jp/index-e.html). See examples below:
 

--- a/CITATIONS.md
+++ b/CITATIONS.md
@@ -28,6 +28,8 @@
 * [GEO](https://pubmed.ncbi.nlm.nih.gov/23193258/)
     > Barrett T, Wilhite SE, Ledoux P, Evangelista C, Kim IF, Tomashevsky M, Marshall KA, Phillippy KH, Sherman PM, Holko M, Yefanov A, Lee H, Zhang N, Robertson CL, Serova N, Davis S, Soboleva A. NCBI GEO: archive for functional genomics data sets--update. Nucleic Acids Res. 2013 Jan;41(Database issue):D991-5. doi: 10.1093/nar/gks1193. Epub 2012 Nov 27. PubMed PMID: 23193258; PubMed Central PMCID: PMC3531084.
 
+* [sra-tools](https://github.com/ncbi/sra-tools)
+
 * [Synapse](https://pubmed.ncbi.nlm.nih.gov/24071850/)
     > Omberg L, Ellrott K, Yuan Y, Kandoth C, Wong C, Kellen MR, Friend SH, Stuart J, Liang H, Margolin AA. Enabling transparent and collaborative computational analysis of 12 tumor types within The Cancer Genome Atlas. Nat Genet. 2013 Oct;45(10):1121-6. doi: 10.1038/ng.2761. PMID: 24071850; PMCID: PMC3950337.
 

--- a/CITATIONS.md
+++ b/CITATIONS.md
@@ -14,6 +14,8 @@
 
 * [Requests](https://docs.python-requests.org/)
 
+* [sra-tools](https://github.com/ncbi/sra-tools)
+
 ## Pipeline resources
 
 * [ENA](https://pubmed.ncbi.nlm.nih.gov/33175160/)
@@ -27,8 +29,6 @@
 
 * [GEO](https://pubmed.ncbi.nlm.nih.gov/23193258/)
     > Barrett T, Wilhite SE, Ledoux P, Evangelista C, Kim IF, Tomashevsky M, Marshall KA, Phillippy KH, Sherman PM, Holko M, Yefanov A, Lee H, Zhang N, Robertson CL, Serova N, Davis S, Soboleva A. NCBI GEO: archive for functional genomics data sets--update. Nucleic Acids Res. 2013 Jan;41(Database issue):D991-5. doi: 10.1093/nar/gks1193. Epub 2012 Nov 27. PubMed PMID: 23193258; PubMed Central PMCID: PMC3531084.
-
-* [sra-tools](https://github.com/ncbi/sra-tools)
 
 * [Synapse](https://pubmed.ncbi.nlm.nih.gov/24071850/)
     > Omberg L, Ellrott K, Yuan Y, Kandoth C, Wong C, Kellen MR, Friend SH, Stuart J, Liang H, Margolin AA. Enabling transparent and collaborative computational analysis of 12 tumor types within The Cancer Genome Atlas. Nat Genet. 2013 Oct;45(10):1121-6. doi: 10.1038/ng.2761. PMID: 24071850; PMCID: PMC3950337.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Via a single file of ids, provided one-per-line (see [example input file](https:
 2. Fetch extensive id metadata via ENA API
 3. Download FastQ files:
     - If direct download links are available from the ENA API, fetch in parallel via `curl` and perform `md5sum` check
-    - Otherwise use `sra-tools` to download `.sra` files and convert them to FastQ
+    - Otherwise use [`sra-tools`](https://github.com/ncbi/sra-tools) to download `.sra` files and convert them to FastQ
 4. Collate id metadata and paths to FastQ files in a single samplesheet
 
 ### Synapse ids

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ On release, automated continuous integration tests run the pipeline on a full-si
 
 ## Pipeline summary
 
-Via a single file of ids, provided one-per-line (see [example input file](https://raw.githubusercontent.com/nf-core/test-datasets/rnaseq/samplesheet/public_database_ids.txt)) the pipeline performs the following steps:
+Via a single file of ids, provided one-per-line (see [example input file](https://raw.githubusercontent.com/nf-core/test-datasets/fetchngs/sra_ids_test.txt)) the pipeline performs the following steps:
 
 ### SRA / ENA / DDBJ / GEO ids
 

--- a/bin/sra_runinfo_to_ftp.py
+++ b/bin/sra_runinfo_to_ftp.py
@@ -112,7 +112,6 @@ def parse_sra_runinfo(file_in):
             else:
                 # In some instances, FTP links don't exist for FastQ files.
                 # These have to be downloaded with the run accession using sra-tools.
-                db_id = row["run_accession"]
                 sample = dict.fromkeys(extensions, None)
                 if row["library_layout"] == "SINGLE":
                     sample["single_end"] = "true"
@@ -160,6 +159,8 @@ def sra_runinfo_to_ftp(files_in, file_out):
             for db_id in sorted(samplesheet):
                 for idx, row in enumerate(samplesheet[db_id], start=1):
                     row["id"] = f"{db_id}_T{idx}"
+                    if 'run_accession' in row:
+                        row["id"] = f"{db_id}_{row['run_accession']}_T{idx}"
                     writer.writerow(row)
 
 

--- a/bin/sra_runinfo_to_ftp.py
+++ b/bin/sra_runinfo_to_ftp.py
@@ -158,9 +158,9 @@ def sra_runinfo_to_ftp(files_in, file_out):
             writer.writeheader()
             for db_id in sorted(samplesheet):
                 for idx, row in enumerate(samplesheet[db_id], start=1):
-                    row["id"] = f"{db_id}_T{idx}"
+                    row["id"] = f"{db_id}"
                     if 'run_accession' in row:
-                        row["id"] = f"{db_id}_{row['run_accession']}_T{idx}"
+                        row["id"] = f"{db_id}_{row['run_accession']}"
                     writer.writerow(row)
 
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -78,9 +78,16 @@ if (params.input_type == 'sra') {
 
         withName: SRATOOLS_FASTERQDUMP {
             publishDir = [
-                path: { "${params.outdir}/fastq" },
-                mode: params.publish_dir_mode,
-                saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+                [
+                    path: { "${params.outdir}/fastq" },
+                    mode: params.publish_dir_mode,
+                    pattern: "*gz"
+                ],
+                [
+                    path: { "${params.outdir}/fastq/md5" },
+                    mode: params.publish_dir_mode,
+                    pattern: "*.md5"
+                ]
             ]
         }
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -186,42 +186,6 @@ process {
 
 > **NB:** We specify just the process name i.e. `STAR_ALIGN` in the config file and not the full task name string that is printed to screen in the error message or on the terminal whilst the pipeline is running i.e. `RNASEQ:ALIGN_STAR:STAR_ALIGN`. You may get a warning suggesting that the process selector isn't recognised but you can ignore that if the process name has been specified correctly. This is something that needs to be fixed upstream in core Nextflow.
 
-### Tool-specific options
-
-For the ultimate flexibility, we have implemented and are using Nextflow DSL2 modules in a way where it is possible for both developers and users to change tool-specific command-line arguments (e.g. providing an additional command-line argument to the `STAR_ALIGN` process) as well as publishing options (e.g. saving files produced by the `STAR_ALIGN` process that aren't saved by default by the pipeline). In the majority of instances, as a user you won't have to change the default options set by the pipeline developer(s), however, there may be edge cases where creating a simple custom config file can improve the behaviour of the pipeline if for example it is failing due to a weird error that requires setting a tool-specific parameter to deal with smaller / larger genomes.
-
-The command-line arguments passed to STAR in the `STAR_ALIGN` module are a combination of:
-
-* Mandatory arguments or those that need to be evaluated within the scope of the module, as supplied in the [`script`](https://github.com/nf-core/rnaseq/blob/4c27ef5610c87db00c3c5a3eed10b1d161abf575/modules/nf-core/software/star/align/main.nf#L49-L55) section of the module file.
-
-* An [`options.args`](https://github.com/nf-core/rnaseq/blob/4c27ef5610c87db00c3c5a3eed10b1d161abf575/modules/nf-core/software/star/align/main.nf#L56) string of non-mandatory parameters that is set to be empty by default in the module but can be overwritten when including the module in the sub-workflow / workflow context via the `addParams` Nextflow option.
-
-The nf-core/rnaseq pipeline has a sub-workflow (see [terminology](https://github.com/nf-core/modules#terminology)) specifically to align reads with STAR and to sort, index and generate some basic stats on the resulting BAM files using SAMtools. At the top of this file we import the `STAR_ALIGN` module via the Nextflow [`include`](https://github.com/nf-core/rnaseq/blob/4c27ef5610c87db00c3c5a3eed10b1d161abf575/subworkflows/nf-core/align_star.nf#L10) keyword and by default the options passed to the module via the `addParams` option are set as an empty Groovy map [here](https://github.com/nf-core/rnaseq/blob/4c27ef5610c87db00c3c5a3eed10b1d161abf575/subworkflows/nf-core/align_star.nf#L5); this in turn means `options.args` will be set to empty by default in the module file too. This is an intentional design choice and allows us to implement well-written sub-workflows composed of a chain of tools that by default run with the bare minimum parameter set for any given tool in order to make it much easier to share across pipelines and to provide the flexibility for users and developers to customise any non-mandatory arguments.
-
-When including the sub-workflow above in the main pipeline workflow we use the same `include` statement, however, we now have the ability to overwrite options for each of the tools in the sub-workflow including the [`align_options`](https://github.com/nf-core/rnaseq/blob/4c27ef5610c87db00c3c5a3eed10b1d161abf575/workflows/rnaseq.nf#L225) variable that will be used specifically to overwrite the optional arguments passed to the `STAR_ALIGN` module. In this case, the options to be provided to `STAR_ALIGN` have been assigned sensible defaults by the developer(s) in the pipeline's [`modules.config`](https://github.com/nf-core/rnaseq/blob/4c27ef5610c87db00c3c5a3eed10b1d161abf575/conf/modules.config#L70-L74) and can be accessed and customised in the [workflow context](https://github.com/nf-core/rnaseq/blob/4c27ef5610c87db00c3c5a3eed10b1d161abf575/workflows/rnaseq.nf#L201-L204) too before eventually passing them to the sub-workflow as a Groovy map called `star_align_options`. These options will then be propagated from `workflow -> sub-workflow -> module`.
-
-As mentioned at the beginning of this section it may also be necessary for users to overwrite the options passed to modules to be able to customise specific aspects of the way in which a particular tool is executed by the pipeline. Given that all of the default module options are stored in the pipeline's `modules.config` as a [`params` variable](https://github.com/nf-core/rnaseq/blob/4c27ef5610c87db00c3c5a3eed10b1d161abf575/conf/modules.config#L24-L25) it is also possible to overwrite any of these options via a custom config file.
-
-Say for example we want to append an additional, non-mandatory parameter (i.e. `--outFilterMismatchNmax 16`) to the arguments passed to the `STAR_ALIGN` module. Firstly, we need to copy across the default `args` specified in the [`modules.config`](https://github.com/nf-core/rnaseq/blob/4c27ef5610c87db00c3c5a3eed10b1d161abf575/conf/modules.config#L71) and create a custom config file that is a composite of the default `args` as well as the additional options you would like to provide. This is very important because Nextflow will overwrite the default value of `args` that you provide via the custom config.
-
-As you will see in the example below, we have:
-
-* appended `--outFilterMismatchNmax 16` to the default `args` used by the module.
-* changed the default `publish_dir` value to where the files will eventually be published in the main results directory.
-* appended `'bam':''` to the default value of `publish_files` so that the BAM files generated by the process will also be saved in the top-level results directory for the module. Note: `'out':'log'` means any file/directory ending in `out` will now be saved in a separate directory called `my_star_directory/log/`.
-
-```nextflow
-params {
-    modules {
-        'star_align' {
-            args          = "--quantMode TranscriptomeSAM --twopassMode Basic --outSAMtype BAM Unsorted --readFilesCommand zcat --runRNGseed 0 --outFilterMultimapNmax 20 --alignSJDBoverhangMin 1 --outSAMattributes NH HI AS NM MD --quantTranscriptomeBan Singleend --outFilterMismatchNmax 16"
-            publish_dir   = "my_star_directory"
-            publish_files = ['out':'log', 'tab':'log', 'bam':'']
-        }
-    }
-}
-```
-
 ### Updating containers
 
 The [Nextflow DSL2](https://www.nextflow.io/docs/latest/dsl2.html) implementation of this pipeline uses one container per process which makes it much easier to maintain and update software dependencies. If for some reason you need to use a different version of a particular tool with the pipeline then you just need to identify the `process` name and override the Nextflow `container` definition for that process using the `withName` declaration. For example, in the [nf-core/viralrecon](https://nf-co.re/viralrecon) pipeline a tool called [Pangolin](https://github.com/cov-lineages/pangolin) has been used during the COVID-19 pandemic to assign lineages to SARS-CoV-2 genome sequenced samples. Given that the lineage assignments change quite frequently it doesn't make sense to re-release the nf-core/viralrecon everytime a new version of Pangolin has been released. However, you can override the default container used by the pipeline by creating a custom config file and passing it as a command-line argument via `-c custom.config`.

--- a/modules/local/sra_fastq_ftp.nf
+++ b/modules/local/sra_fastq_ftp.nf
@@ -26,7 +26,7 @@ process SRA_FASTQ_FTP {
             -L ${fastq[0]} \\
             -o ${meta.id}.fastq.gz
 
-        echo "${meta.md5_1} ${meta.id}.fastq.gz" > ${meta.id}.fastq.gz.md5
+        echo "${meta.md5_1}  ${meta.id}.fastq.gz" > ${meta.id}.fastq.gz.md5
         md5sum -c ${meta.id}.fastq.gz.md5
 
         cat <<-END_VERSIONS > versions.yml
@@ -41,7 +41,7 @@ process SRA_FASTQ_FTP {
             -L ${fastq[0]} \\
             -o ${meta.id}_1.fastq.gz
 
-        echo "${meta.md5_1} ${meta.id}_1.fastq.gz" > ${meta.id}_1.fastq.gz.md5
+        echo "${meta.md5_1}  ${meta.id}_1.fastq.gz" > ${meta.id}_1.fastq.gz.md5
         md5sum -c ${meta.id}_1.fastq.gz.md5
 
         curl \\
@@ -49,7 +49,7 @@ process SRA_FASTQ_FTP {
             -L ${fastq[1]} \\
             -o ${meta.id}_2.fastq.gz
 
-        echo "${meta.md5_2} ${meta.id}_2.fastq.gz" > ${meta.id}_2.fastq.gz.md5
+        echo "${meta.md5_2}  ${meta.id}_2.fastq.gz" > ${meta.id}_2.fastq.gz.md5
         md5sum -c ${meta.id}_2.fastq.gz.md5
 
         cat <<-END_VERSIONS > versions.yml

--- a/modules/local/sratools_fasterqdump.nf
+++ b/modules/local/sratools_fasterqdump.nf
@@ -12,8 +12,9 @@ process SRATOOLS_FASTERQDUMP {
     tuple val(meta), path(sra)
 
     output:
-    tuple val(meta), path(output), emit: reads
-    path "versions.yml"          , emit: versions
+    tuple val(meta), path(fastq_output), emit: reads
+    tuple val(meta), path(md5_output)  , emit: md5
+    path "versions.yml"                , emit: versions
 
     script:
     def args   = task.ext.args  ?: ''
@@ -22,7 +23,8 @@ process SRATOOLS_FASTERQDUMP {
     // Paired-end data extracted by fasterq-dump (--split-3 the default) always creates
     // *_1.fastq *_2.fastq files but sometimes also an additional *.fastq file
     // for unpaired reads which we ignore here.
-    output = meta.single_end ? '*.fastq.gz' : '*_{1,2}.fastq.gz'
+    fastq_output = meta.single_end ? '*.fastq.gz'     : '*_{1,2}.fastq.gz'
+    md5_output   = meta.single_end ? '*.fastq.gz.md5' : '*_{1,2}.fastq.gz.md5'
     """
     eval "\$(vdb-config -o n NCBI_SETTINGS | sed 's/[" ]//g')"
     if [[ ! -f "\${NCBI_SETTINGS}" ]]; then
@@ -40,6 +42,22 @@ process SRATOOLS_FASTERQDUMP {
         --no-name \\
         --processes $task.cpus \\
         *.fastq
+
+    ## Rename FastQ files by meta.id
+    if [ -f  ${sra.name}.fastq.gz ]; then
+        mv ${sra.name}.fastq.gz ${meta.id}.fastq.gz
+        md5sum ${meta.id}.fastq.gz > ${meta.id}.fastq.gz.md5
+    fi
+
+    if [ -f  ${sra.name}_1.fastq.gz ]; then
+        mv ${sra.name}_1.fastq.gz ${meta.id}_1.fastq.gz
+        md5sum ${meta.id}_1.fastq.gz > ${meta.id}_1.fastq.gz.md5
+    fi
+
+    if [ -f  ${sra.name}_2.fastq.gz ]; then
+        mv ${sra.name}_2.fastq.gz ${meta.id}_2.fastq.gz
+        md5sum ${meta.id}_2.fastq.gz > ${meta.id}_2.fastq.gz.md5
+    fi
 
     cat <<-END_VERSIONS > versions.yml
     ${task.process.tokenize(':').last()}:

--- a/modules/local/sratools_prefetch.nf
+++ b/modules/local/sratools_prefetch.nf
@@ -26,7 +26,7 @@ process SRATOOLS_PREFETCH {
         printf '${config}' > "\${NCBI_SETTINGS}"
     fi
 
-    prefetch \\
+    retry_with_backoff.sh prefetch \\
         $args \\
         --progress \\
         $id

--- a/nextflow.config
+++ b/nextflow.config
@@ -16,6 +16,7 @@ params {
     ena_metadata_fields        = null
     sample_mapping_fields      = 'experiment_accession,run_accession,sample_accession,experiment_alias,run_alias,sample_alias,experiment_title,sample_title,sample_description,description'
     synapse_config             = null
+    force_sratools_download    = false
     skip_fastq_download        = false
 
     // Boilerplate options

--- a/nextflow.config
+++ b/nextflow.config
@@ -14,7 +14,7 @@ params {
     input_type                 = 'sra'
     nf_core_pipeline           = null
     ena_metadata_fields        = null
-    sample_mapping_fields      = 'run_accession,sample_accession,experiment_alias,run_alias,sample_alias,experiment_title,sample_title,sample_description,description'
+    sample_mapping_fields      = 'experiment_accession,run_accession,sample_accession,experiment_alias,run_alias,sample_alias,experiment_title,sample_title,sample_description,description'
     synapse_config             = null
     skip_fastq_download        = false
 

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -50,6 +50,11 @@
                     "fa_icon": "fab fa-apple",
                     "description": "Name of supported nf-core pipeline e.g.  'rnaseq'. A samplesheet for direct use with the pipeline will be created with the appropriate columns."
                 },
+                "force_sratools_download": {
+                    "type": "boolean",
+                    "fa_icon": "fas fa-tools",
+                    "description": "Force download FastQ files via sra-tools instead of via the ENA FTP."
+                },
                 "skip_fastq_download": {
                     "type": "boolean",
                     "fa_icon": "fas fa-fast-forward",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -43,7 +43,7 @@
                     "type": "string",
                     "fa_icon": "fas fa-globe-americas",
                     "description": "Comma-separated list of ENA metadata fields used to create a separate 'id_mappings.csv' and 'multiqc_config.yml' with selected fields that can be used to rename samples in general and in MultiQC.",
-                    "default": "run_accession,sample_accession,experiment_alias,run_alias,sample_alias,experiment_title,sample_title,sample_description,description"
+                    "default": "experiment_accession,run_accession,sample_accession,experiment_alias,run_alias,sample_alias,experiment_title,sample_title,sample_description,description"
                 },
                 "nf_core_pipeline": {
                     "type": "string",

--- a/subworkflows/local/sra_fastq_sratools.nf
+++ b/subworkflows/local/sra_fastq_sratools.nf
@@ -5,7 +5,7 @@
 include { SRATOOLS_PREFETCH    } from '../../modules/local/sratools_prefetch.nf'
 include { SRATOOLS_FASTERQDUMP } from '../../modules/local/sratools_fasterqdump.nf'
 
-workflow SRA_FASTQ {
+workflow SRA_FASTQ_SRATOOLS {
     take:
     sra_ids  // channel: [ val(meta), val(id) ]
 

--- a/workflows/sra.nf
+++ b/workflows/sra.nf
@@ -22,7 +22,7 @@ WorkflowSra.initialise(params, log, valid_params)
 include { SRA_IDS_TO_RUNINFO      } from '../modules/local/sra_ids_to_runinfo'
 include { SRA_RUNINFO_TO_FTP      } from '../modules/local/sra_runinfo_to_ftp'
 include { SRA_FASTQ_FTP           } from '../modules/local/sra_fastq_ftp'
-include { SRA_FASTQ               } from '../subworkflows/local/sra_fastq'
+include { SRA_FASTQ_SRATOOLS      } from '../subworkflows/local/sra_fastq_sratools'
 include { SRA_TO_SAMPLESHEET      } from '../modules/local/sra_to_samplesheet'
 include { SRA_MERGE_SAMPLESHEET   } from '../modules/local/sra_merge_samplesheet'
 include { MULTIQC_MAPPINGS_CONFIG } from '../modules/local/multiqc_mappings_config'
@@ -89,7 +89,7 @@ workflow SRA {
         //
         // SUBWORKFLOW: Download sequencing reads without FTP links using sra-tools.
         //
-        SRA_FASTQ (
+        SRA_FASTQ_SRATOOLS (
             ch_sra_reads.sra.map { meta, reads -> [ meta, meta.run_accession ] }
         )
         ch_versions = ch_versions.mix(SRA_FASTQ.out.versions.first())

--- a/workflows/sra.nf
+++ b/workflows/sra.nf
@@ -92,13 +92,13 @@ workflow SRA {
         SRA_FASTQ_SRATOOLS (
             ch_sra_reads.sra.map { meta, reads -> [ meta, meta.run_accession ] }
         )
-        ch_versions = ch_versions.mix(SRA_FASTQ.out.versions.first())
+        ch_versions = ch_versions.mix(SRA_FASTQ_SRATOOLS.out.versions.first())
 
         //
         // MODULE: Stage FastQ files downloaded by SRA together and auto-create a samplesheet
         //
         SRA_TO_SAMPLESHEET (
-            SRA_FASTQ_FTP.out.fastq.mix(SRA_FASTQ.out.reads),
+            SRA_FASTQ_FTP.out.fastq.mix(SRA_FASTQ_SRATOOLS.out.reads),
             params.nf_core_pipeline ?: '',
             params.sample_mapping_fields
         )


### PR DESCRIPTION
* Renamed output FastQ files by `EXPID_RUNID*fastq.gz` syntax
* Renamed FastQ files downloaded via `sra-tools` by above convention too and added md5sum generation step
* Added `--force_sratools_download` to force download FastQ files via `sra-tools` as opposed to ENA FTP.