### PR TITLE
Set a default docker registry outside of profile scope.

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -96,7 +96,6 @@ profiles {
     }
     docker {
         docker.enabled         = true
-        docker.registry        = 'quay.io'
         docker.userEmulation   = true
         conda.enabled          = false
         singularity.enabled    = false
@@ -178,6 +177,9 @@ env {
 
 // Capture exit codes from upstream processes when piping
 process.shell = ['/bin/bash', '-euo', 'pipefail']
+
+// Set default docker registry (will be unused unless pulling docker images)
+docker.registry = 'quay.io'
 
 def trace_timestamp = new java.util.Date().format( 'yyyy-MM-dd_HH-mm-ss')
 timeline {


### PR DESCRIPTION
The `docker.registry` configuration should always be set, as running on cloud executors will need to pull docker images but will not necessarily use the `docker` profile.


## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/fetchngs/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/fetchngs _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
