### PR TITLE
sra_runinfo_to_ftp.py: Avoid dependency on Python 3.8

### DIFF
--- a/bin/sra_runinfo_to_ftp.py
+++ b/bin/sra_runinfo_to_ftp.py
@@ -61,7 +61,8 @@ def parse_sra_runinfo(file_in):
     with open(file_in, "r", newline="") as fin:
         reader = csv.DictReader(fin, delimiter="\t", skipinitialspace=True)
         header = list(reader.fieldnames)
-        if missing := frozenset(columns).difference(frozenset(header)):
+        missing = frozenset(columns).difference(frozenset(header))
+        if missing:
             logger.critical(f"The following expected columns are missing from {file_in}: " f"{', '.join(missing)}.")
             sys.exit(1)
         for row in reader:


### PR DESCRIPTION
The ":=" assignment was introduced in Python 3.8. On HPC environments this is not always available. 
