### PR TITLE
Add_minleghth_0_fasterq_dump

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -77,7 +77,7 @@ if (params.input_type == 'sra') {
         }
 
         withName: SRATOOLS_FASTERQDUMP {
-            ext.args = '--split-files --include-technical'
+            ext.args = '--split-files --include-technical --min-read-len 0'
             publishDir = [
                 path: { "${params.outdir}/fastq" },
                 mode: params.publish_dir_mode,


### PR DESCRIPTION
Previously, if the sample contains empty reads, they would be quietly
discarded:

```
$ fastq-dump --split-files SRR12848126
Rejected 52 READS because READLEN < 1
Read 1517 spots for SRR12848126
Written 1517 spots for SRR12848126
```

This can cause problems when using paired end reads in downstream
processes that expect len(R1) == len(R2).


## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/fetchngs/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/fetchngs _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
