### PR TITLE
Revert sratools fasterqdump version

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -13,7 +13,8 @@
                     "sratools/fasterqdump": {
                         "branch": "master",
                         "git_sha": "e719354ba77df0a1bd310836aa2039b45c29d620",
-                        "installed_by": ["fastq_download_prefetch_fasterqdump_sratools"]
+                        "installed_by": ["fastq_download_prefetch_fasterqdump_sratools"],
+                        "patch": "modules/nf-core/sratools/fasterqdump/sratools-fasterqdump.diff"
                     },
                     "sratools/prefetch": {
                         "branch": "master",

--- a/modules/nf-core/sratools/fasterqdump/environment.yml
+++ b/modules/nf-core/sratools/fasterqdump/environment.yml
@@ -4,5 +4,5 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::sra-tools=3.0.8
+  - bioconda::sra-tools=2.11.0
   - conda-forge::pigz=2.6

--- a/modules/nf-core/sratools/fasterqdump/main.nf
+++ b/modules/nf-core/sratools/fasterqdump/main.nf
@@ -4,8 +4,8 @@ process SRATOOLS_FASTERQDUMP {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/mulled-v2-5f89fe0cd045cb1d615630b9261a1d17943a9b6a:2f4a4c900edd6801ff0068c2b3048b4459d119eb-0' :
-        'biocontainers/mulled-v2-5f89fe0cd045cb1d615630b9261a1d17943a9b6a:2f4a4c900edd6801ff0068c2b3048b4459d119eb-0' }"
+        'https://depot.galaxyproject.org/singularity/mulled-v2-5f89fe0cd045cb1d615630b9261a1d17943a9b6a:6a9ff0e76ec016c3d0d27e0c0d362339f2d787e6-0' :
+        'quay.io/biocontainers/mulled-v2-5f89fe0cd045cb1d615630b9261a1d17943a9b6a:6a9ff0e76ec016c3d0d27e0c0d362339f2d787e6-0' }"
 
     input:
     tuple val(meta), path(sra)

--- a/modules/nf-core/sratools/fasterqdump/sratools-fasterqdump.diff
+++ b/modules/nf-core/sratools/fasterqdump/sratools-fasterqdump.diff
@@ -1,0 +1,63 @@
+Changes in module 'nf-core/sratools/fasterqdump'
+--- modules/nf-core/sratools/fasterqdump/main.nf
++++ modules/nf-core/sratools/fasterqdump/main.nf
+@@ -4,8 +4,8 @@
+ 
+     conda "${moduleDir}/environment.yml"
+     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+-        'https://depot.galaxyproject.org/singularity/mulled-v2-5f89fe0cd045cb1d615630b9261a1d17943a9b6a:2f4a4c900edd6801ff0068c2b3048b4459d119eb-0' :
+-        'biocontainers/mulled-v2-5f89fe0cd045cb1d615630b9261a1d17943a9b6a:2f4a4c900edd6801ff0068c2b3048b4459d119eb-0' }"
++        'https://depot.galaxyproject.org/singularity/mulled-v2-5f89fe0cd045cb1d615630b9261a1d17943a9b6a:6a9ff0e76ec016c3d0d27e0c0d362339f2d787e6-0' :
++        'quay.io/biocontainers/mulled-v2-5f89fe0cd045cb1d615630b9261a1d17943a9b6a:6a9ff0e76ec016c3d0d27e0c0d362339f2d787e6-0' }"
+ 
+     input:
+     tuple val(meta), path(sra)
+
+--- /dev/null
++++ modules/nf-core/sratools/fasterqdump/nextflow.config
+@@ -0,0 +1,10 @@
++process {
++    withName: SRATOOLS_FASTERQDUMP {
++        ext.args = '--split-files --include-technical'
++        publishDir = [
++            path: { "${params.outdir}/fastq" },
++            mode: params.publish_dir_mode,
++            pattern: "*.fastq.gz"
++        ]
++    }
++}
+--- modules/nf-core/sratools/fasterqdump/environment.yml
++++ modules/nf-core/sratools/fasterqdump/environment.yml
+@@ -4,5 +4,5 @@
+   - bioconda
+   - defaults
+ dependencies:
+-  - bioconda::sra-tools=3.0.8
++  - bioconda::sra-tools=2.11.0
+   - conda-forge::pigz=2.6
+
+--- modules/nf-core/sratools/fasterqdump/tests/main.nf.test
++++ modules/nf-core/sratools/fasterqdump/tests/main.nf.test
+@@ -3,11 +3,9 @@
+     script "../main.nf"
+     config "./nextflow.config"
+     process "SRATOOLS_FASTERQDUMP"
+-    tag "modules"
+-    tag "modules_nfcore"
+-    tag "untar"
+-    tag "sratools"
+-    tag "sratools/fasterqdump"
++    tag "SRATOOLS_FASTERQDUMP"
++
++    tag "UNTAR"
+ 
+     test("Single-end") {
+ 
+
+--- modules/nf-core/sratools/fasterqdump/tests/tags.yml
++++ /dev/null
+@@ -1,2 +0,0 @@
+-sratools/fasterqdump:
+-  - modules/nf-core/sratools/fasterqdump/**
+
+************************************************************


### PR DESCRIPTION
Partial fix for #221 

Reverting the version for sratools/fasterqdump from 3.0.8 -> 2.11.0 because a number of users have reported having issues when they have a `.` (dot) anywhere in their path. We can update this version when the fix has been pushed upstream (see https://github.com/ncbi/sra-tools/issues/865)

In the meantime, anyone wanting to use more recent support for `ngc` files can use v3.0.8 via a custom config file passed to the pipeline:

```
process {
    withName: 'SRATOOLS_FASTERQDUMP' {
        container = 'quay.io/biocontainers/mulled-v2-5f89fe0cd045cb1d615630b9261a1d17943a9b6a:2f4a4c900edd6801ff0068c2b3048b4459d119eb-0'
    }
}
```