### PR TITLE
Revert to using FTP for default downloads over Aspera

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### :warning: Major enhancements
 
-- The Aspera CLI was recently added to [Bioconda](https://anaconda.org/bioconda/aspera-cli) and we have added it as another way of downloading FastQ files on top of the existing FTP and sra-tools support. In our limited benchmarks on all public Clouds we found ~50% speed-up in download times compared to FTP! We are not aware of any obvious downsides and have made this the default download method in the pipeline. You can however, revert to using FTP and sra-tools using the `--force_ftp_download` and `--force_sratools_download` parameters, respectively. We would love to have your feedback!
+- The Aspera CLI was recently added to [Bioconda](https://anaconda.org/bioconda/aspera-cli) and we have added it as another way of downloading FastQ files on top of the existing FTP and sra-tools support. In our limited benchmarks on all public Clouds we found ~50% speed-up in download times compared to FTP! FTP downloads will still be the default download method but you can however, choose to use sra-tools or Aspera using the `--force_sratools_download` or `--force_aspera_download` parameters, respectively. We would love to have your feedback!
 - Support for Synapse ids has been dropped in this release. We haven't had any feedback from users whether it is being used or not. Users can run earlier versions of the pipeline if required.
 - We have significantly refactored and standardised the way we are using nf-test within this pipeline. This pipeline is now the current, best-practice implementation for nf-test usage on nf-core. We required a number of features to be added to nf-test and a huge shoutout to [Lukas Forer](https://github.com/lukfor) for entertaining our requests and implementing them within upstream :heart:!
 
@@ -60,11 +60,11 @@ Thank you to everyone else that has contributed by reporting bugs, enhancements 
 
 ### Parameters
 
-| Old parameter      | New parameter          |
-| ------------------ | ---------------------- |
-|                    | `--force_ftp_download` |
-| `--input_type`     |                        |
-| `--synapse_config` |                        |
+| Old parameter      | New parameter             |
+| ------------------ | ------------------------- |
+|                    | `--force_aspera_download` |
+| `--input_type`     |                           |
+| `--synapse_config` |                           |
 
 > **NB:** Parameter has been **updated** if both old and new parameter information is present.
 > **NB:** Parameter has been **added** if just the new parameter information is present.

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ Via a single file of ids, provided one-per-line (see [example input file](https:
 2. Fetch extensive id metadata via ENA API
 3. Download FastQ files:
    - If direct download links are available from the ENA API:
-     - Fetch in parallel via `aspera-cli` and perform `md5sum` check (default)
-     - Fetch in parallel via `wget` and perform `md5sum` check. Use `--force_ftp_download` to force this behaviour.
+     - Fetch in parallel via `wget` and perform `md5sum` check (default).
+     - Fetch in parallel via `aspera-cli` and perform `md5sum` check. Use `--force_aspera_download` to force this behaviour.
    - Otherwise use [`sra-tools`](https://github.com/ncbi/sra-tools) to download `.sra` files and convert them to FastQ. Use `--force_sratools_download` to force this behaviour.
 4. Collate id metadata and paths to FastQ files in a single samplesheet
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -70,13 +70,9 @@ This highlights that there is a discrepancy between the read data hosted on the 
 
 See [issue #260](https://github.com/nf-core/fetchngs/issues/260) for more details.
 
-### Bypass Aspera data download
+### Primary options for downloading data
 
-If the appropriate download links are available, the pipeline uses the Aspera CLI by default to download FastQ files. If you are having issues and prefer to use FTP or sra-tools instead, you can use the [`--force_ftp_download`](https://nf-co.re/fetchngs/parameters#force_ftp_download) and [`--force_sratools_download`](https://nf-co.re/fetchngs/parameters#force_sratools_download) parameters, respectively.
-
-### Bypass `FTP` data download
-
-If FTP connections are blocked on your network use the [`--force_sratools_download`](https://nf-co.re/fetchngs/parameters#force_sratools_download) parameter to force the pipeline to download data using sra-tools instead of the ENA FTP.
+If the appropriate download links are available, the pipeline uses FTP by default to download FastQ files. If you are having issues and prefer to use sra-tools or Aspera instead, you can use the [`--force_sratools_download`](https://nf-co.re/fetchngs/parameters#force_sratools_download) or [`--force_aspera_download`](https://nf-co.re/fetchngs/parameters#force_aspera_download) parameters, respectively.
 
 ### Downloading dbGAP data with JWT
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -15,7 +15,7 @@ params {
     nf_core_rnaseq_strandedness = 'auto'
     ena_metadata_fields         = null
     sample_mapping_fields       = 'experiment_accession,run_accession,sample_accession,experiment_alias,run_alias,sample_alias,experiment_title,sample_title,sample_description'
-    force_ftp_download          = false
+    force_aspera_download       = false
     force_sratools_download     = false
     skip_fastq_download         = false
     dbgap_key                   = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -47,11 +47,11 @@
                     "help_text": "The default is 'auto' which can be used with nf-core/rnaseq v3.10 onwards to auto-detect strandedness during the pipeline execution.",
                     "default": "auto"
                 },
-                "force_ftp_download": {
+                "force_aspera_download": {
                     "type": "boolean",
                     "fa_icon": "fas fa-tools",
-                    "description": "Force download FASTQ files via FTP instead of via the Aspera CLI.",
-                    "help_text": "If the Aspera CLI is not working on your infrastructure use this flag to force the pipeline to download data via FTP."
+                    "description": "Force download FASTQ files via Aspera CLI instead of via FTP.",
+                    "help_text": "If FTP downloads are not working on your infrastructure use this flag to force the pipeline to download data via the Aspera CLI."
                 },
                 "force_sratools_download": {
                     "type": "boolean",

--- a/workflows/sra/tests/main.nf.test
+++ b/workflows/sra/tests/main.nf.test
@@ -8,7 +8,7 @@ nextflow_workflow {
     // Dependencies
     tag "SRA_IDS_TO_RUNINFO"
     tag "SRA_RUNINFO_TO_FTP"
-    tag "ASPERA_CLI"
+    tag "SRA_FASTQ_FTP"
     tag "SRA_TO_SAMPLESHEET"
     tag "MULTIQC_MAPPINGS_CONFIG"
 

--- a/workflows/sra/tests/sra_force_aspera_download.nf.test
+++ b/workflows/sra/tests/sra_force_aspera_download.nf.test
@@ -8,11 +8,11 @@ nextflow_workflow {
     // Dependencies
     tag "SRA_IDS_TO_RUNINFO"
     tag "SRA_RUNINFO_TO_FTP"
-    tag "SRA_FASTQ_FTP"
+    tag "ASPERA_CLI"
     tag "SRA_TO_SAMPLESHEET"
     tag "MULTIQC_MAPPINGS_CONFIG"
 
-    test("Parameters: --force_ftp_download") {
+    test("Parameters: --force_aspera_download") {
 
         when {
             workflow {
@@ -22,7 +22,7 @@ nextflow_workflow {
             }
             params {
                 outdir = "$outputDir"
-                force_ftp_download = true
+                force_aspera_download = true
             }
         }
 

--- a/workflows/sra/tests/sra_nf_core_pipeline_atacseq.nf.test
+++ b/workflows/sra/tests/sra_nf_core_pipeline_atacseq.nf.test
@@ -8,7 +8,7 @@ nextflow_workflow {
     // Dependencies
     tag "SRA_IDS_TO_RUNINFO"
     tag "SRA_RUNINFO_TO_FTP"
-    tag "ASPERA_CLI"
+    tag "SRA_FASTQ_FTP"
     tag "SRA_TO_SAMPLESHEET"
     tag "MULTIQC_MAPPINGS_CONFIG"
 

--- a/workflows/sra/tests/sra_nf_core_pipeline_rnaseq.nf.test
+++ b/workflows/sra/tests/sra_nf_core_pipeline_rnaseq.nf.test
@@ -8,7 +8,7 @@ nextflow_workflow {
     // Dependencies
     tag "SRA_IDS_TO_RUNINFO"
     tag "SRA_RUNINFO_TO_FTP"
-    tag "ASPERA_CLI"
+    tag "SRA_FASTQ_FTP"
     tag "SRA_TO_SAMPLESHEET"
     tag "MULTIQC_MAPPINGS_CONFIG"
 

--- a/workflows/sra/tests/sra_nf_core_pipeline_taxprofiler.nf.test
+++ b/workflows/sra/tests/sra_nf_core_pipeline_taxprofiler.nf.test
@@ -8,7 +8,7 @@ nextflow_workflow {
     // Dependencies
     tag "SRA_IDS_TO_RUNINFO"
     tag "SRA_RUNINFO_TO_FTP"
-    tag "ASPERA_CLI"
+    tag "SRA_FASTQ_FTP"
     tag "SRA_TO_SAMPLESHEET"
     tag "MULTIQC_MAPPINGS_CONFIG"
 

--- a/workflows/sra/tests/sra_nf_core_pipeline_viralrecon.nf.test
+++ b/workflows/sra/tests/sra_nf_core_pipeline_viralrecon.nf.test
@@ -8,7 +8,7 @@ nextflow_workflow {
     // Dependencies
     tag "SRA_IDS_TO_RUNINFO"
     tag "SRA_RUNINFO_TO_FTP"
-    tag "ASPERA_CLI"
+    tag "SRA_FASTQ_FTP"
     tag "SRA_TO_SAMPLESHEET"
     tag "MULTIQC_MAPPINGS_CONFIG"
 


### PR DESCRIPTION
Since making Aspera the default download method on the `dev` branch we have observed some flakiness in the Github Actions CI/CD and an issue with using Singularity. Maybe it was a bit premature to make it the default without real-world testing. We did test Aspera on public Clouds via Seqera Platform and it worked out of the box but I am going to revert back to making FTP the default download method until we can collect and fix any issues.

- Rename `--force_ftp_download` to `--force_aspera_download`
- Update tests where required
