### PR TITLE
confirm-pass will pass if no tests are triggered

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
     if: always()
     steps:
       - name: All tests ok
-        if: ${{ success() || !contains(needs.*.result, 'failure') }}
+        if: ${{ !contains(needs.*.result, 'failure') }}
         run: exit 0
       - name: One or more tests failed
         if: ${{ contains(needs.*.result, 'failure') }}


### PR DESCRIPTION
confirm-pass was failing if no tests were triggered. See https://github.com/nf-core/fetchngs/actions/runs/7948765770/job/21699169109 for an example.

This removes the requirement for a `success()` status, which should allow confirm-pass to always pass. 

confirm pass should fail if _any_ check has failed and pass if _no_ checks fail. 

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/fetchngs/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/fetchngs _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
