### PR TITLE
Replace --force_* parameters with --download_method parameter

### DIFF
--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -7,5 +7,4 @@ lint:
     - lib/Utils.groovy
     - lib/WorkflowMain.groovy
   files_unchanged:
-    - .gitignore
     - assets/sendmail_template.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### :warning: Major enhancements
 
-- The Aspera CLI was recently added to [Bioconda](https://anaconda.org/bioconda/aspera-cli) and we have added it as another way of downloading FastQ files on top of the existing FTP and sra-tools support. In our limited benchmarks on all public Clouds we found ~50% speed-up in download times compared to FTP! FTP downloads will still be the default download method but you can however, choose to use sra-tools or Aspera using the `--force_sratools_download` or `--force_aspera_download` parameters, respectively. We would love to have your feedback!
+- The Aspera CLI was recently added to [Bioconda](https://anaconda.org/bioconda/aspera-cli) and we have added it as another way of downloading FastQ files in addition to the existing FTP and sra-tools support. In our limited benchmarks on all public Clouds we found ~50% speed-up in download times compared to FTP! FTP downloads will still be the default download method (i.e. `--download_method ftp`) but you can choose to use sra-tools or Aspera using `--download_method sratools` or `--download_method aspera`, respectively. We would love to have your feedback!
+- The `--force_sratools_download` parameter has been deprecated in favour of using `--download_method <method>` to explicitly specify the download method; available options are `ftp`, `sratools` or `aspera`.
 - Support for Synapse ids has been dropped in this release. We haven't had any feedback from users whether it is being used or not. Users can run earlier versions of the pipeline if required.
 - We have significantly refactored and standardised the way we are using nf-test within this pipeline. This pipeline is now the current, best-practice implementation for nf-test usage on nf-core. We required a number of features to be added to nf-test and a huge shoutout to [Lukas Forer](https://github.com/lukfor) for entertaining our requests and implementing them within upstream :heart:!
 
@@ -60,11 +61,12 @@ Thank you to everyone else that has contributed by reporting bugs, enhancements 
 
 ### Parameters
 
-| Old parameter      | New parameter             |
-| ------------------ | ------------------------- |
-|                    | `--force_aspera_download` |
-| `--input_type`     |                           |
-| `--synapse_config` |                           |
+| Old parameter               | New parameter       |
+| --------------------------- | ------------------- |
+|                             | `--download_method` |
+| `--input_type`              |                     |
+| `--force_sratools_download` |                     |
+| `--synapse_config`          |                     |
 
 > **NB:** Parameter has been **updated** if both old and new parameter information is present.
 > **NB:** Parameter has been **added** if just the new parameter information is present.

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ Via a single file of ids, provided one-per-line (see [example input file](https:
 2. Fetch extensive id metadata via ENA API
 3. Download FastQ files:
    - If direct download links are available from the ENA API:
-     - Fetch in parallel via `wget` and perform `md5sum` check (default).
-     - Fetch in parallel via `aspera-cli` and perform `md5sum` check. Use `--force_aspera_download` to force this behaviour.
-   - Otherwise use [`sra-tools`](https://github.com/ncbi/sra-tools) to download `.sra` files and convert them to FastQ. Use `--force_sratools_download` to force this behaviour.
+     - Fetch in parallel via `wget` and perform `md5sum` check (`--download_method ftp`; default).
+     - Fetch in parallel via `aspera-cli` and perform `md5sum` check. Use `--download_method aspera` to force this behaviour.
+   - Otherwise use [`sra-tools`](https://github.com/ncbi/sra-tools) to download `.sra` files and convert them to FastQ. Use `--download_method sratools` to force this behaviour.
 4. Collate id metadata and paths to FastQ files in a single samplesheet
 
 ## Pipeline output

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -66,13 +66,13 @@ SRR9320616_2.fastq
 SRR9320616_3.fastq
 ```
 
-This highlights that there is a discrepancy between the read data hosted on the ENA API and what can actually be fetched from sra-tools, where the latter seems to be the source of truth. If you anticipate that you may have more than 2 FastQ files per sample, it is recommended to use this pipeline with the `--force_sratools_download` parameter.
+This highlights that there is a discrepancy between the read data hosted on the ENA API and what can actually be fetched from sra-tools, where the latter seems to be the source of truth. If you anticipate that you may have more than 2 FastQ files per sample, it is recommended to use this pipeline with the `--download_method sratools` parameter.
 
 See [issue #260](https://github.com/nf-core/fetchngs/issues/260) for more details.
 
 ### Primary options for downloading data
 
-If the appropriate download links are available, the pipeline uses FTP by default to download FastQ files. If you are having issues and prefer to use sra-tools or Aspera instead, you can use the [`--force_sratools_download`](https://nf-co.re/fetchngs/parameters#force_sratools_download) or [`--force_aspera_download`](https://nf-co.re/fetchngs/parameters#force_aspera_download) parameters, respectively.
+If the appropriate download links are available, the pipeline uses FTP by default to download FastQ files by setting the `--download_method ftp` parameter. If you are having issues and prefer to use sra-tools or Aspera instead, you can set the [`--download_method`](https://nf-co.re/fetchngs/parameters#download_method) parameter to `--download_method sratools` or `--download_method aspera`, respectively.
 
 ### Downloading dbGAP data with JWT
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -45,7 +45,7 @@ params {
     max_time                    = '240.h'
 
     // Schema validation default options
-    validationFailUnrecognisedParams = false
+    validationFailUnrecognisedParams = true
     validationLenientMode            = false
     validationShowHiddenParams       = false
     validationSchemaIgnoreParams     = ''

--- a/nextflow.config
+++ b/nextflow.config
@@ -15,8 +15,7 @@ params {
     nf_core_rnaseq_strandedness = 'auto'
     ena_metadata_fields         = null
     sample_mapping_fields       = 'experiment_accession,run_accession,sample_accession,experiment_alias,run_alias,sample_alias,experiment_title,sample_title,sample_description'
-    force_aspera_download       = false
-    force_sratools_download     = false
+    download_method             = 'ftp'
     skip_fastq_download         = false
     dbgap_key                   = null
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -45,11 +45,15 @@ params {
     max_time                    = '240.h'
 
     // Schema validation default options
-    validationFailUnrecognisedParams = true
+    validationFailUnrecognisedParams = false
     validationLenientMode            = false
     validationShowHiddenParams       = false
     validationSchemaIgnoreParams     = ''
     validate_params                  = true
+
+    // Deprecated options
+    // See: https://github.com/nf-core/fetchngs/pull/279/files#r1494459480
+    force_sratools_download          = false
 
 }
 

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -30,7 +30,7 @@
                 },
                 "sample_mapping_fields": {
                     "type": "string",
-                    "fa_icon": "fas fa-globe-americas",
+                    "fa_icon": "fas fa-columns",
                     "description": "Comma-separated list of ENA metadata fields used to create a separate 'id_mappings.csv' and 'multiqc_config.yml' with selected fields that can be used to rename samples in general and in MultiQC.",
                     "default": "experiment_accession,run_accession,sample_accession,experiment_alias,run_alias,sample_alias,experiment_title,sample_title,sample_description"
                 },
@@ -42,22 +42,18 @@
                 },
                 "nf_core_rnaseq_strandedness": {
                     "type": "string",
-                    "fa_icon": "fas fa-car",
+                    "fa_icon": "fas fa-dna",
                     "description": "Value for 'strandedness' entry added to samplesheet created when using '--nf_core_pipeline rnaseq'.",
                     "help_text": "The default is 'auto' which can be used with nf-core/rnaseq v3.10 onwards to auto-detect strandedness during the pipeline execution.",
                     "default": "auto"
                 },
-                "force_aspera_download": {
-                    "type": "boolean",
-                    "fa_icon": "fas fa-tools",
-                    "description": "Force download FASTQ files via Aspera CLI instead of via FTP.",
-                    "help_text": "If FTP downloads are not working on your infrastructure use this flag to force the pipeline to download data via the Aspera CLI."
-                },
-                "force_sratools_download": {
-                    "type": "boolean",
-                    "fa_icon": "fas fa-tools",
-                    "description": "Force download FASTQ files via sra-tools instead of via the ENA FTP.",
-                    "help_text": "If FTP connections are blocked on your network use this flag to force the pipeline to download data using sra-tools instead of the ENA FTP."
+                "download_method": {
+                    "type": "string",
+                    "default": "ftp",
+                    "fa_icon": "fas fa-download",
+                    "enum": ["aspera", "ftp", "sratools"],
+                    "description": "Method to download FastQ files. Available options are 'aspera', 'ftp' or 'sratools'. Default is 'ftp'.",
+                    "help_text": "FTP and Aspera CLI download FastQ files directly from the ENA FTP whereas sratools uses sra-tools to download *.sra files and convert to FastQ."
                 },
                 "skip_fastq_download": {
                     "type": "boolean",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -249,6 +249,22 @@
                     "help_text": "Allows string values that are parseable as numbers or booleans. For further information see [JSONSchema docs](https://github.com/everit-org/json-schema#lenient-mode)."
                 }
             }
+        },
+        "deprecated_options": {
+            "title": "Deprecated options",
+            "type": "object",
+            "description": "List of parameters that have been deprecated.",
+            "default": "",
+            "fa_icon": "fas fa-calendar-times",
+            "properties": {
+                "force_sratools_download": {
+                    "type": "boolean",
+                    "fa_icon": "fas fa-times-circle",
+                    "description": "This parameter has been deprecated. Please use '--download_method sratools' instead.",
+                    "enum": [false],
+                    "hidden": true
+                }
+            }
         }
     },
     "allOf": [
@@ -263,6 +279,9 @@
         },
         {
             "$ref": "#/definitions/generic_options"
+        },
+        {
+            "$ref": "#/definitions/deprecated_options"
         }
     ]
 }

--- a/workflows/sra/main.nf
+++ b/workflows/sra/main.nf
@@ -73,19 +73,19 @@ workflow SRA {
                     // meta.fastq_aspera is a metadata string with ENA fasp links supported by Aspera
                         // For single-end: 'fasp.sra.ebi.ac.uk:/vol1/fastq/ERR116/006/ERR1160846/ERR1160846.fastq.gz'
                         // For paired-end: 'fasp.sra.ebi.ac.uk:/vol1/fastq/SRR130/020/SRR13055520/SRR13055520_1.fastq.gz;fasp.sra.ebi.ac.uk:/vol1/fastq/SRR130/020/SRR13055520/SRR13055520_2.fastq.gz'
-                    if (meta.fastq_aspera && params.force_aspera_download) {
+                    if (meta.fastq_aspera && params.download_method == 'aspera') {
                         download_method = 'aspera'
                     }
-                    if ((!meta.fastq_aspera && !meta.fastq_1) || params.force_sratools_download) {
+                    if ((!meta.fastq_aspera && !meta.fastq_1) || params.download_method == 'sratools') {
                         download_method = 'sratools'
                     }
 
+                    aspera: download_method == 'aspera'
+                        return [ meta, meta.fastq_aspera.tokenize(';').take(2) ]
                     ftp: download_method == 'ftp'
                         return [ meta, [ meta.fastq_1, meta.fastq_2 ] ]
                     sratools: download_method == 'sratools'
                         return [ meta, meta.run_accession ]
-                    aspera: download_method == 'aspera'
-                        return [ meta, meta.fastq_aspera.tokenize(';').take(2) ]
             }
             .set { ch_sra_reads }
 

--- a/workflows/sra/tests/sra_download_method_aspera.nf.test
+++ b/workflows/sra/tests/sra_download_method_aspera.nf.test
@@ -3,7 +3,7 @@ nextflow_workflow {
     name "Test workflow: sra/main.nf"
     script "../main.nf"
     workflow "SRA"
-    tag "SRA_FORCE_FTP_DOWNLOAD"
+    tag "SRA_DOWNLOAD_METHOD_ASPERA"
 
     // Dependencies
     tag "SRA_IDS_TO_RUNINFO"
@@ -12,7 +12,7 @@ nextflow_workflow {
     tag "SRA_TO_SAMPLESHEET"
     tag "MULTIQC_MAPPINGS_CONFIG"
 
-    test("Parameters: --force_aspera_download") {
+    test("Parameters: --download_method aspera") {
 
         when {
             workflow {
@@ -22,7 +22,7 @@ nextflow_workflow {
             }
             params {
                 outdir = "$outputDir"
-                force_aspera_download = true
+                download_method = 'aspera'
             }
         }
 

--- a/workflows/sra/tests/sra_download_method_sratools.nf.test
+++ b/workflows/sra/tests/sra_download_method_sratools.nf.test
@@ -3,7 +3,7 @@ nextflow_workflow {
     name "Test workflow: sra/main.nf"
     script "../main.nf"
     workflow "SRA"
-    tag "SRA_FORCE_SRATOOLS_DOWNLOAD"
+    tag "SRA_DOWNLOAD_METHOD_SRATOOLS"
 
     // Dependencies
     tag "FASTQ_DOWNLOAD_PREFETCH_FASTERQDUMP_SRATOOLS"
@@ -12,7 +12,7 @@ nextflow_workflow {
     tag "SRA_TO_SAMPLESHEET"
     tag "MULTIQC_MAPPINGS_CONFIG"
 
-    test("Parameters: --force_sratools_download") {
+    test("Parameters: --download_method sratools") {
 
         when {
             workflow {
@@ -22,7 +22,7 @@ nextflow_workflow {
             }
             params {
                 outdir = "$outputDir"
-                force_sratools_download = true
+                download_method = 'sratools'
             }
         }
 


### PR DESCRIPTION
As outlined in https://github.com/nf-core/fetchngs/pull/277#issuecomment-1951447682, I think it makes sense to have a more generic parameter to select a download method rather than individual `--force_*` options.