### PR TITLE
Replace base SHA with original pull request base SHA instead of updated one so diff is more restrictive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         id: hash
         run: |
           git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
-          echo commit=$(git merge-base --fork-point origin/${{ github.ref }} ${{ github.base_ref }}) >> $GITHUB_OUTPUT
+          echo commit=$(git merge-base --fork-point HEAD ${{ github.base_ref }}) >> $GITHUB_OUTPUT
 
       - uses: tj-actions/changed-files@v42
         id: changed_files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,13 +37,12 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - uses: tj-actions/changed-files@v42
         id: changed_files
         with:
-          fetch_depth: 2
-          base_sha: ${{ github.event.pull_request.base.sha }}
+          base_sha: ${{ github.event.pull_request.head.sha }}
           dir_names: "true"
           output_renamed_files_as_deleted_and_added: "true"
           # Define list of additional rules for testing paths

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: get-common-commit-hash
+        id: hash
+        run: |
+          echo commit=$(git merge-base --fork-point ${{ github.head_ref }} ${{ github.base_ref }}) >> $GITHUB_OUTPUT
+
       - uses: tj-actions/changed-files@v42
         id: changed_files
         with:
-          base_sha: ${{ github.event.pull_request.head.sha }}
+          base_sha: ${{ steps.hash.outputs.commit }}
           dir_names: "true"
           output_renamed_files_as_deleted_and_added: "true"
           # Define list of additional rules for testing paths
@@ -58,7 +63,6 @@ jobs:
               - conf/*
               - main.nf
               - nextflow_schema.json
-
           files_ignore: |
             .git*
             .gitpod.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: get-common-commit-hash
         id: hash
         run: |
-          git fetch origin ${{ github.base_ref }}
+          git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
           echo commit=$(git merge-base --fork-point origin/${{ github.ref }} ${{ github.base_ref }}) >> $GITHUB_OUTPUT
 
       - uses: tj-actions/changed-files@v42

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 2
 
       - uses: tj-actions/changed-files@v42
         id: changed_files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
       - uses: tj-actions/changed-files@v42
         id: changed_files
         with:
+          fetch_depth: 2
           base_sha: ${{ github.event.pull_request.base.sha }}
           dir_names: "true"
           output_renamed_files_as_deleted_and_added: "true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
           export COMMIT=$(git merge-base --fork-point HEAD ${{ github.base_ref }})
           echo commit=$COMMIT >> $GITHUB_OUTPUT
-          git diff --dirstat=files,0 $COMMIT | sed 's/[ 0-9.%]//g'
+          git diff --dirstat=files,0 $COMMIT | sed 's/[ 0-9.%]//g' | jq -Rsc 'split("\n")[:-1]'
 
       - uses: tj-actions/changed-files@v42
         id: changed_files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: get-common-commit-hash
         id: hash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         id: hash
         run: |
           git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
-          echo commit=$(git merge-base --fork-point ${{ github.head_ref }} ${{ github.base_ref }}) >> $GITHUB_OUTPUT
+          echo commit=$(git merge-base --fork-point ${{ github.ref_name }} ${{ github.base_ref }}) >> $GITHUB_OUTPUT
 
       - uses: tj-actions/changed-files@v42
         id: changed_files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,14 @@ jobs:
           python-version: "3.11"
           architecture: "x64"
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: get-common-commit-hash
         id: hash
         run: |
+          git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
           echo commit=$(git merge-base --fork-point ${{ github.head_ref }} ${{ github.base_ref }}) >> $GITHUB_OUTPUT
 
       - uses: tj-actions/changed-files@v42

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
       - uses: tj-actions/changed-files@v42
         id: changed_files
         with:
+          base_sha: ${{ github.event.pull_request.base.sha }}
           dir_names: "true"
           output_renamed_files_as_deleted_and_added: "true"
           # Define list of additional rules for testing paths

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,9 @@ jobs:
         id: hash
         run: |
           git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
-          echo commit=$(git merge-base --fork-point HEAD ${{ github.base_ref }}) >> $GITHUB_OUTPUT
+          export COMMIT=$(git merge-base --fork-point HEAD ${{ github.base_ref }})
+          echo commit=$COMMIT >> $GITHUB_OUTPUT
+          git diff --dirstat=files,0 $COMMIT | sed 's/[ 0-9.%]//g'
 
       - uses: tj-actions/changed-files@v42
         id: changed_files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,8 @@ jobs:
       - name: get-common-commit-hash
         id: hash
         run: |
-          git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
-          echo commit=$(git merge-base --fork-point ${{ github.ref }} ${{ github.base_ref }}) >> $GITHUB_OUTPUT
+          git fetch origin ${{ github.base_ref }}
+          echo commit=$(git merge-base --fork-point origin/${{ github.ref }} ${{ github.base_ref }}) >> $GITHUB_OUTPUT
 
       - uses: tj-actions/changed-files@v42
         id: changed_files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         id: hash
         run: |
           git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
-          echo commit=$(git merge-base --fork-point ${{ github.ref_name }} ${{ github.base_ref }}) >> $GITHUB_OUTPUT
+          echo commit=$(git merge-base --fork-point ${{ github.ref }} ${{ github.base_ref }}) >> $GITHUB_OUTPUT
 
       - uses: tj-actions/changed-files@v42
         id: changed_files


### PR DESCRIPTION
This PR changes the action to detect file changes to restrict to the initial target commit of the PR. Hopefully it will only detect relevant file changes. I've branched it off a much older commit than the up-to-date dev one, so if it fails many more changes will be detected.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/fetchngs/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/fetchngs _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
