### PR TITLE
Update Github Action to run full-sized test for all 3 download methods

### DIFF
--- a/.github/workflows/cloud_tests_full.yml
+++ b/.github/workflows/cloud_tests_full.yml
@@ -73,8 +73,9 @@ jobs:
   run-full-tests-on-gcp:
     if: ${{ github.event.inputs.platform == 'gcp' || !github.event.inputs }}
     runs-on: ubuntu-latest
-    matrix:
-      download_method: ["aspera", "ftp", "sratools"]
+    strategy:
+      matrix:
+        download_method: ["aspera", "ftp", "sratools"]
     steps:
       - uses: seqeralabs/action-tower-launch@v2
         with:

--- a/.github/workflows/cloud_tests_full.yml
+++ b/.github/workflows/cloud_tests_full.yml
@@ -19,6 +19,9 @@ jobs:
   run-full-tests-on-aws:
     if: ${{ github.event.inputs.platform == 'all' || github.event.inputs.platform == 'aws' || !github.event.inputs }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        download_method: ["aspera", "ftp", "sratools"]
     steps:
       - uses: seqeralabs/action-tower-launch@v2
         with:
@@ -26,13 +29,14 @@ jobs:
           access_token: ${{ secrets.TOWER_ACCESS_TOKEN }}
           compute_env: ${{ secrets.TOWER_CE_AWS_CPU }}
           workdir: "${{ secrets.TOWER_BUCKET_AWS }}/work/fetchngs/work-${{ github.sha }}"
-          run_name: "aws_fetchngs_full"
+          run_name: "aws_fetchngs_full_${{ matrix.download_method }}"
           revision: ${{ github.sha }}
           profiles: test_full
           parameters: |
             {
                 "hook_url": "${{ secrets.MEGATESTS_ALERTS_SLACK_HOOK_URL }}",
-                "outdir": "${{ secrets.TOWER_BUCKET_AWS }}/fetchngs/results-${{ github.sha }}/"
+                "download_method": "${{ matrix.download_method }}",
+                "outdir": "${{ secrets.TOWER_BUCKET_AWS }}/fetchngs/results-${{ github.sha }}/download_method_${{ matrix.download_method }}/"
             }
       - uses: actions/upload-artifact@v3
         with:
@@ -42,6 +46,9 @@ jobs:
   run-full-tests-on-azure:
     if: ${{ github.event.inputs.platform == 'all' || github.event.inputs.platform == 'azure' || !github.event.inputs }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        download_method: ["aspera", "ftp", "sratools"]
     steps:
       - uses: seqeralabs/action-tower-launch@v2
         with:
@@ -49,13 +56,14 @@ jobs:
           access_token: ${{ secrets.TOWER_ACCESS_TOKEN }}
           compute_env: ${{ secrets.TOWER_CE_AZURE_CPU }}
           workdir: "${{ secrets.TOWER_BUCKET_AZURE }}/work/fetchngs/work-${{ github.sha }}"
-          run_name: "azure_fetchngs_full"
+          run_name: "azure_fetchngs_full_${{ matrix.download_method }}"
           revision: ${{ github.sha }}
           profiles: test_full
           parameters: |
             {
                 "hook_url": "${{ secrets.MEGATESTS_ALERTS_SLACK_HOOK_URL }}",
-                "outdir": "${{ secrets.TOWER_BUCKET_AZURE }}/fetchngs/results-${{ github.sha }}/"
+                "download_method": "${{ matrix.download_method }}",
+                "outdir": "${{ secrets.TOWER_BUCKET_AZURE }}/fetchngs/results-${{ github.sha }}/download_method_${{ matrix.download_method }}/"
             }
       - uses: actions/upload-artifact@v3
         with:
@@ -65,6 +73,8 @@ jobs:
   run-full-tests-on-gcp:
     if: ${{ github.event.inputs.platform == 'gcp' || !github.event.inputs }}
     runs-on: ubuntu-latest
+    matrix:
+      download_method: ["aspera", "ftp", "sratools"]
     steps:
       - uses: seqeralabs/action-tower-launch@v2
         with:
@@ -72,13 +82,14 @@ jobs:
           access_token: ${{ secrets.TOWER_ACCESS_TOKEN }}
           compute_env: ${{ secrets.TOWER_CE_GCP_CPU }}
           workdir: "${{ secrets.TOWER_BUCKET_GCP }}/work/fetchngs/work-${{ github.sha }}"
-          run_name: "gcp_fetchngs_full"
+          run_name: "gcp_fetchngs_full_${{ matrix.download_method }}"
           revision: ${{ github.sha }}
           profiles: test_full
           parameters: |
             {
                 "hook_url": "${{ secrets.MEGATESTS_ALERTS_SLACK_HOOK_URL }}",
-                "outdir": "${{ secrets.TOWER_BUCKET_GCP }}/fetchngs/results-${{ github.sha }}/"
+                "download_method": "${{ matrix.download_method }}",
+                "outdir": "${{ secrets.TOWER_BUCKET_GCP }}/fetchngs/results-${{ github.sha }}/download_method_${{ matrix.download_method }}/"
             }
       - uses: actions/upload-artifact@v3
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Thank you to everyone else that has contributed by reporting bugs, enhancements 
 - [PR #268](https://github.com/nf-core/fetchngs/pull/268) - Add mermaid diagram
 - [PR #273](https://github.com/nf-core/fetchngs/pull/273) - Update utility subworkflows
 - [PR #283](https://github.com/nf-core/fetchngs/pull/283) - Template update for nf-core/tools v2.13
+- [PR #288](https://github.com/nf-core/fetchngs/pull/288) - Update Github Action to run full-sized test for all 3 download methods
 
 ### Software dependencies
 


### PR DESCRIPTION
Be nice to do simple benchmarking on all public clouds across the different download methods we have available in the pipeline i.e.
- `--download_method ftp` (default)
- `--download_method aspera`
- `--download_method sratools`
