### PR TITLE
Remove mentions of deprecated Synapse functionality in pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Thank you to everyone else that has contributed by reporting bugs, enhancements 
 - [PR #268](https://github.com/nf-core/fetchngs/pull/268) - Add mermaid diagram
 - [PR #273](https://github.com/nf-core/fetchngs/pull/273) - Update utility subworkflows
 - [PR #283](https://github.com/nf-core/fetchngs/pull/283) - Template update for nf-core/tools v2.13
+- [PR #290](https://github.com/nf-core/fetchngs/pull/290) - Remove mentions of deprecated Synapse functionality in pipeline
 
 ### Software dependencies
 

--- a/CITATIONS.md
+++ b/CITATIONS.md
@@ -36,9 +36,6 @@
 
   > Barrett T, Wilhite SE, Ledoux P, Evangelista C, Kim IF, Tomashevsky M, Marshall KA, Phillippy KH, Sherman PM, Holko M, Yefanov A, Lee H, Zhang N, Robertson CL, Serova N, Davis S, Soboleva A. NCBI GEO: archive for functional genomics data sets--update. Nucleic Acids Res. 2013 Jan;41(Database issue):D991-5. doi: 10.1093/nar/gks1193. Epub 2012 Nov 27. PubMed PMID: 23193258; PubMed Central PMCID: PMC3531084.
 
-- [Synapse](https://pubmed.ncbi.nlm.nih.gov/24071850/)
-  > Omberg L, Ellrott K, Yuan Y, Kandoth C, Wong C, Kellen MR, Friend SH, Stuart J, Liang H, Margolin AA. Enabling transparent and collaborative computational analysis of 12 tumor types within The Cancer Genome Atlas. Nat Genet. 2013 Oct;45(10):1121-6. doi: 10.1038/ng.2761. PMID: 24071850; PMCID: PMC3950337.
-
 ## Software packaging/containerisation/testing tools
 
 - [Anaconda](https://anaconda.com)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ## Introduction
 
-**nf-core/fetchngs** is a bioinformatics pipeline to fetch metadata and raw FastQ files from both public and private databases. At present, the pipeline supports SRA / ENA / DDBJ / GEO / Synapse ids (see [usage docs](https://nf-co.re/fetchngs/usage#introduction)).
+**nf-core/fetchngs** is a bioinformatics pipeline to fetch metadata and raw FastQ files from both public databases. At present, the pipeline supports SRA / ENA / DDBJ / GEO ids (see [usage docs](https://nf-co.re/fetchngs/usage#introduction)).
 
 ```mermaid
 flowchart LR
@@ -114,7 +114,7 @@ For more details about the output files and reports, please refer to the
 
 ## Credits
 
-nf-core/fetchngs was originally written by Harshil Patel ([@drpatelh](https://github.com/drpatelh)) from [Seqera Labs, Spain](https://seqera.io/) and Jose Espinosa-Carrasco ([@JoseEspinosa](https://github.com/JoseEspinosa)) from [The Comparative Bioinformatics Group](https://www.crg.eu/en/cedric_notredame) at [The Centre for Genomic Regulation, Spain](https://www.crg.eu/). Support for download of sequencing reads without FTP links via sra-tools was added by Moritz E. Beber ([@Midnighter](https://github.com/Midnighter)) from [Unseen Bio ApS, Denmark](https://unseenbio.com). The Synapse workflow was added by Daisy Han [@daisyhan97](https://github.com/daisyhan97) and Bruno Grande [@BrunoGrandePhD](https://github.com/BrunoGrandePhD) from [Sage Bionetworks, Seattle](https://sagebionetworks.org/).
+nf-core/fetchngs was originally written by Harshil Patel ([@drpatelh](https://github.com/drpatelh)) from [Seqera Labs, Spain](https://seqera.io/) and Jose Espinosa-Carrasco ([@JoseEspinosa](https://github.com/JoseEspinosa)) from [The Comparative Bioinformatics Group](https://www.crg.eu/en/cedric_notredame) at [The Centre for Genomic Regulation, Spain](https://www.crg.eu/). Support for download of sequencing reads without FTP links via sra-tools was added by Moritz E. Beber ([@Midnighter](https://github.com/Midnighter)) from [Unseen Bio ApS, Denmark](https://unseenbio.com).
 
 ## Contributions and Support
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,7 +6,7 @@
 
 ## Introduction
 
-The pipeline has been set-up to automatically download and process the raw FastQ files from both public and private repositories. Identifiers can be provided in a file, one-per-line via the `--input` parameter. Currently, the following types of example identifiers are supported:
+The pipeline has been set-up to automatically download and process the raw FastQ files from public repositories. Identifiers can be provided in a file, one-per-line via the `--input` parameter. Currently, the following types of example identifiers are supported:
 
 | `SRA`        | `ENA`        | `DDBJ`       | `GEO`      |
 | ------------ | ------------ | ------------ | ---------- |

--- a/subworkflows/local/utils_nfcore_fetchngs_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_fetchngs_pipeline/main.nf
@@ -158,7 +158,7 @@ def isSraId(input) {
         if (num_match == total_ids) {
             is_sra = true
         } else {
-            error("Mixture of ids provided via --input: ${no_match_ids.join(', ')}\nPlease provide either SRA / ENA / GEO / DDBJ or Synapse ids!")
+            error("Mixture of ids provided via --input: ${no_match_ids.join(', ')}\nPlease provide either SRA / ENA / GEO / DDBJ ids!")
         }
     }
     return is_sra

--- a/subworkflows/local/utils_nfcore_fetchngs_pipeline/tests/main.function.nf.test.snap
+++ b/subworkflows/local/utils_nfcore_fetchngs_pipeline/tests/main.function.nf.test.snap
@@ -12,11 +12,5 @@
             true
         ],
         "timestamp": "2024-01-19T16:36:43.68958"
-    },
-    "Function isSynapseId": {
-        "content": [
-            true
-        ],
-        "timestamp": "2024-01-19T16:37:12.992364"
     }
 }


### PR DESCRIPTION
Synapse functionality will be deprecated in the next release. Spotted some places where we forgot to remove mentions.