### PR TITLE
export CONDA_PREFIX into container when using Singularity and Apptainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Special thanks to the following for their contributions to the release:
 - [Alexandru Mizeranschi](https://github.com/nicolae06)
 - [Alexander Blaessle](https://github.com/alexblaessle)
 - [Lukas Forer](https://github.com/lukfor)
+- [Matt Niederhuber](https://github.com/mniederhuber)
 - [Maxime Garcia](https://github.com/maxulysse)
 - [Sateesh Peri](https://github.com/sateeshperi)
 - [Sebastian Uhrig](https://github.com/suhrig)
@@ -54,6 +55,7 @@ Thank you to everyone else that has contributed by reporting bugs, enhancements 
 - [PR #294](https://github.com/nf-core/fetchngs/pull/294) - Replace mermaid diagram with subway map
 - [PR #295](https://github.com/nf-core/fetchngs/pull/295) - Be less stringent with test expectations for CI
 - [PR #296](https://github.com/nf-core/fetchngs/pull/296) - Remove params.outdir from tests where required and update snapshots
+- [PR #298](https://github.com/nf-core/fetchngs/pull/298) - `export CONDA_PREFIX` into container when using Singularity and Apptainer
 
 ### Software dependencies
 

--- a/modules/local/aspera_cli/main.nf
+++ b/modules/local/aspera_cli/main.nf
@@ -18,8 +18,11 @@ process ASPERA_CLI {
 
     script:
     def args = task.ext.args ?: ''
+    def conda_prefix = ['singularity', 'apptainer'].contains(workflow.containerEngine) ? "export CONDA_PREFIX=/usr/local" : ""
     if (meta.single_end) {
         """
+        $conda_prefix
+
         ascp \\
             $args \\
             -i \$CONDA_PREFIX/etc/aspera/aspera_bypass_dsa.pem \\
@@ -36,6 +39,8 @@ process ASPERA_CLI {
         """
     } else {
         """
+        $conda_prefix
+
         ascp \\
             $args \\
             -i \$CONDA_PREFIX/etc/aspera/aspera_bypass_dsa.pem \\

--- a/nextflow.config
+++ b/nextflow.config
@@ -70,14 +70,6 @@ try {
 // Workflow specific configs
 includeConfig './workflows/sra/nextflow.config'
 
-// Load nf-core/fetchngs custom profiles from different institutions.
-// Warning: Uncomment only if a pipeline-specific institutional config already exists on nf-core/configs!
-// try {
-//   includeConfig "${params.custom_config_base}/pipeline/fetchngs.config"
-// } catch (Exception e) {
-//   System.err.println("WARNING: Could not load nf-core/config/fetchngs profiles: ${params.custom_config_base}/pipeline/fetchngs.config")
-// }
-
 profiles {
     debug {
         dumpHashes             = true


### PR DESCRIPTION
Closes https://github.com/nf-core/fetchngs/issues/292

A few users have reported that the `CONDA_PREFIX` variable is not available in the Aspera Singularity Biocontainer available on Galaxy:
https://depot.galaxyproject.org/singularity/aspera-cli:4.14.0--hdfd78af_1

It does appear to be set in the Docker Biocontainer as expected. Ideally, we would rebuild the Singularity container to export this variable. This fix essentially checks the profile that users are running and exports the variable within the process to make it available when using `-profile singularity` or `-profile apptainer`. We can remove this patch when it is exported into the container as expected.