### PR TITLE
Update module sratools prefetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PR #299](https://github.com/nf-core/fetchngs/pull/299) - Template update for nf-core/tools v2.13.1
 - [PR #300](https://github.com/nf-core/fetchngs/pull/300) - Use file paths instead of tags for testing matrix, should make matrices more efficient
 - [PR #303](https://github.com/nf-core/fetchngs/pull/303) - Update wget container for SRA_FASTQ_FTP from 1.20.1 to 1.21.4
+- [PR #305](https://github.com/nf-core/fetchngs/pull/305) - Update module sratools/prefetch for reliable download integrity check
 
 ### Software dependencies
 
 | Dependency | Old version | New version |
 | ---------- | ----------- | ----------- |
 | `wget`     | 1.20.1      | 1.21.4      |
+| `sratools` | 3.0.8       | 3.1.0       |
 
 ## [[1.12.0](https://github.com/nf-core/fetchngs/releases/tag/1.12.0)] - 2024-02-29
 

--- a/modules.json
+++ b/modules.json
@@ -18,7 +18,7 @@
                     },
                     "sratools/prefetch": {
                         "branch": "master",
-                        "git_sha": "5caf7640a9ef1d18d765d55339be751bb0969dfa",
+                        "git_sha": "1fc29f92e439d5631fdf34b8ac4687297d70f5ec",
                         "installed_by": ["fastq_download_prefetch_fasterqdump_sratools"]
                     },
                     "untar": {
@@ -32,7 +32,7 @@
                 "nf-core": {
                     "fastq_download_prefetch_fasterqdump_sratools": {
                         "branch": "master",
-                        "git_sha": "5caf7640a9ef1d18d765d55339be751bb0969dfa",
+                        "git_sha": "1fc29f92e439d5631fdf34b8ac4687297d70f5ec",
                         "installed_by": ["subworkflows"]
                     },
                     "utils_nextflow_pipeline": {

--- a/modules/nf-core/sratools/prefetch/environment.yml
+++ b/modules/nf-core/sratools/prefetch/environment.yml
@@ -4,4 +4,5 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::sra-tools=3.0.8
+  - bioconda::sra-tools=3.1.0
+  - conda-forge::curl=8.5.0

--- a/modules/nf-core/sratools/prefetch/main.nf
+++ b/modules/nf-core/sratools/prefetch/main.nf
@@ -4,8 +4,8 @@ process SRATOOLS_PREFETCH {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/sra-tools:3.0.8--h9f5acd7_0' :
-        'biocontainers/sra-tools:3.0.8--h9f5acd7_0' }"
+        'https://depot.galaxyproject.org/singularity/sra-tools:3.1.0--h9f5acd7_0' :
+        'biocontainers/sra-tools:3.1.0--h9f5acd7_0' }"
 
     input:
     tuple val(meta), val(id)

--- a/modules/nf-core/sratools/prefetch/tests/main.nf.test
+++ b/modules/nf-core/sratools/prefetch/tests/main.nf.test
@@ -2,6 +2,10 @@ nextflow_process {
     name "Test Process SRATOOLS_PREFETCH"
     script "../main.nf"
     process "SRATOOLS_PREFETCH"
+    tag "modules"
+    tag "modules_nfcore"
+    tag "sratools"
+    tag "sratools/prefetch"
 
     test("sratools/prefetch") {
 

--- a/modules/nf-core/sratools/prefetch/tests/main.nf.test.snap
+++ b/modules/nf-core/sratools/prefetch/tests/main.nf.test.snap
@@ -14,7 +14,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,c967dea4135cb75490e1e801c4639efc"
+                    "versions.yml:md5,83d1b23f5ff5b2ad1b96d17d7d7594ee"
                 ],
                 "sra": [
                     [
@@ -28,7 +28,7 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,c967dea4135cb75490e1e801c4639efc"
+                    "versions.yml:md5,83d1b23f5ff5b2ad1b96d17d7d7594ee"
                 ]
             }
         ],
@@ -53,7 +53,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,c967dea4135cb75490e1e801c4639efc"
+                    "versions.yml:md5,83d1b23f5ff5b2ad1b96d17d7d7594ee"
                 ],
                 "sra": [
                     [
@@ -67,7 +67,7 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,c967dea4135cb75490e1e801c4639efc"
+                    "versions.yml:md5,83d1b23f5ff5b2ad1b96d17d7d7594ee"
                 ]
             }
         ],

--- a/modules/nf-core/sratools/prefetch/tests/tags.yml
+++ b/modules/nf-core/sratools/prefetch/tests/tags.yml
@@ -1,0 +1,2 @@
+sratools/prefetch:
+  - modules/nf-core/sratools/prefetch/**

--- a/subworkflows/nf-core/fastq_download_prefetch_fasterqdump_sratools/tests/main.nf.test
+++ b/subworkflows/nf-core/fastq_download_prefetch_fasterqdump_sratools/tests/main.nf.test
@@ -3,10 +3,12 @@ nextflow_workflow {
     name "Test workflow: fastq_download_prefetch_fasterqdump_sratools/main.nf"
     script "../main.nf"
     workflow "FASTQ_DOWNLOAD_PREFETCH_FASTERQDUMP_SRATOOLS"
-
-    tag "CUSTOM_SRATOOLSNCBISETTINGS"
-    tag "SRATOOLS_PREFETCH"
-    tag "SRATOOLS_FASTERQDUMP"
+    tag "subworkflows"
+    tag "subworkflows_nfcore"
+    tag "custom/sratoolsncbisettings"
+    tag "sratools/prefetch"
+    tag "sratools/fasterqdump"
+    tag "subworkflows/fastq_download_prefetch_fasterqdump_sratools"
 
     test("Parameters: default") {
 

--- a/subworkflows/nf-core/fastq_download_prefetch_fasterqdump_sratools/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/fastq_download_prefetch_fasterqdump_sratools/tests/main.nf.test.snap
@@ -28,7 +28,7 @@
     },
     "test_pe_reads_2_size": {
         "content": [
-            2013376
+            2011460
         ],
         "meta": {
             "nf-test": "0.8.4",

--- a/subworkflows/nf-core/fastq_download_prefetch_fasterqdump_sratools/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/fastq_download_prefetch_fasterqdump_sratools/tests/main.nf.test.snap
@@ -40,8 +40,8 @@
         "content": [
             [
                 "versions.yml:md5,1a2218ff913fc33408bffccb081b5048",
-                "versions.yml:md5,2f3b3a13b36dabf13f09327613d5558d",
-                "versions.yml:md5,98d78bba9f3da39a0b7db6e9c7dcc224"
+                "versions.yml:md5,53d6e983afde3a28add2ffc6b7eba4f3",
+                "versions.yml:md5,9c558ff624585a6eee82a19c8c0136db"
             ]
         ],
         "meta": {
@@ -52,7 +52,7 @@
     },
     "test_pe_reads_1_size": {
         "content": [
-            2013376
+            2011460
         ],
         "meta": {
             "nf-test": "0.8.4",

--- a/subworkflows/nf-core/fastq_download_prefetch_fasterqdump_sratools/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/fastq_download_prefetch_fasterqdump_sratools/tests/main.nf.test.snap
@@ -40,8 +40,8 @@
         "content": [
             [
                 "versions.yml:md5,1a2218ff913fc33408bffccb081b5048",
-                "versions.yml:md5,53d6e983afde3a28add2ffc6b7eba4f3",
-                "versions.yml:md5,2f3b3a13b36dabf13f09327613d5558d"
+                "versions.yml:md5,2f3b3a13b36dabf13f09327613d5558d",
+                "versions.yml:md5,53d6e983afde3a28add2ffc6b7eba4f3"
             ]
         ],
         "meta": {

--- a/subworkflows/nf-core/fastq_download_prefetch_fasterqdump_sratools/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/fastq_download_prefetch_fasterqdump_sratools/tests/main.nf.test.snap
@@ -41,7 +41,7 @@
             [
                 "versions.yml:md5,1a2218ff913fc33408bffccb081b5048",
                 "versions.yml:md5,53d6e983afde3a28add2ffc6b7eba4f3",
-                "versions.yml:md5,9c558ff624585a6eee82a19c8c0136db"
+                "versions.yml:md5,2f3b3a13b36dabf13f09327613d5558d"
             ]
         ],
         "meta": {

--- a/subworkflows/nf-core/fastq_download_prefetch_fasterqdump_sratools/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/fastq_download_prefetch_fasterqdump_sratools/tests/main.nf.test.snap
@@ -28,7 +28,7 @@
     },
     "test_pe_reads_2_size": {
         "content": [
-            2011460
+            2013376
         ],
         "meta": {
             "nf-test": "0.8.4",
@@ -52,7 +52,7 @@
     },
     "test_pe_reads_1_size": {
         "content": [
-            2011460
+            2013376
         ],
         "meta": {
             "nf-test": "0.8.4",

--- a/subworkflows/nf-core/fastq_download_prefetch_fasterqdump_sratools/tests/tags.yml
+++ b/subworkflows/nf-core/fastq_download_prefetch_fasterqdump_sratools/tests/tags.yml
@@ -1,0 +1,2 @@
+subworkflows/fastq_download_prefetch_fasterqdump_sratools:
+  - subworkflows/nf-core/fastq_download_prefetch_fasterqdump_sratools/**


### PR DESCRIPTION
This PR fixes #285. Downloads using sratools often resulted in corrupt files, because the tool to check the file integrity, `vdb-validate` is not always reliable. This PR updates the module `sratools/prefetch`, which includes a fix which performs a manual MD5 sum check in cases where `vdb-validate` is unreliable.

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [X] Make sure your code lints (`nf-core lint`).
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [X] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [X] `CHANGELOG.md` is updated.
