### PR TITLE
Refactor ext config as params

### DIFF
--- a/modules/local/aspera_cli/main.nf
+++ b/modules/local/aspera_cli/main.nf
@@ -10,6 +10,7 @@ process ASPERA_CLI {
     input:
     tuple val(meta), val(fastq)
     val user
+    var args
 
     output:
     tuple val(meta), path("*fastq.gz"), emit: fastq
@@ -17,7 +18,6 @@ process ASPERA_CLI {
     path "versions.yml"               , emit: versions
 
     script:
-    def args = task.ext.args ?: ''
     def conda_prefix = ['singularity', 'apptainer'].contains(workflow.containerEngine) ? "export CONDA_PREFIX=/usr/local" : ""
     if (meta.single_end) {
         """

--- a/modules/local/aspera_cli/main.nf
+++ b/modules/local/aspera_cli/main.nf
@@ -10,7 +10,7 @@ process ASPERA_CLI {
     input:
     tuple val(meta), val(fastq)
     val user
-    var args
+    val args
 
     output:
     tuple val(meta), path("*fastq.gz"), emit: fastq

--- a/modules/local/aspera_cli/nextflow.config
+++ b/modules/local/aspera_cli/nextflow.config
@@ -1,6 +1,5 @@
 process {
     withName: 'ASPERA_CLI' {
-        ext.args = '-QT -l 300m -P33001'
         publishDir = [
             [
                 path: { "${params.outdir}/fastq" },

--- a/modules/local/sra_fastq_ftp/main.nf
+++ b/modules/local/sra_fastq_ftp/main.nf
@@ -11,6 +11,7 @@ process SRA_FASTQ_FTP {
 
     input:
     tuple val(meta), val(fastq)
+    val args
 
     output:
     tuple val(meta), path("*fastq.gz"), emit: fastq
@@ -18,7 +19,6 @@ process SRA_FASTQ_FTP {
     path "versions.yml"               , emit: versions
 
     script:
-    def args = task.ext.args ?: ''
     if (meta.single_end) {
         """
         wget \\

--- a/modules/local/sra_fastq_ftp/nextflow.config
+++ b/modules/local/sra_fastq_ftp/nextflow.config
@@ -1,6 +1,5 @@
 process {
     withName: 'SRA_FASTQ_FTP' {
-        ext.args = '-t 5 -nv -c -T 60'
         publishDir = [
             [
                 path: { "${params.outdir}/fastq" },

--- a/modules/nf-core/sratools/fasterqdump/main.nf
+++ b/modules/nf-core/sratools/fasterqdump/main.nf
@@ -11,6 +11,8 @@ process SRATOOLS_FASTERQDUMP {
     tuple val(meta), path(sra)
     path ncbi_settings
     path certificate
+    val fasterqdump_args    // = '--split-files --include-technical'
+    val pigz_args           // = ''
 
     output:
     tuple val(meta), path('*.fastq.gz'), emit: reads
@@ -20,8 +22,6 @@ process SRATOOLS_FASTERQDUMP {
     task.ext.when == null || task.ext.when
 
     script:
-    def args = task.ext.args ?: ''
-    def args2 = task.ext.args2 ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def outfile = meta.single_end ? "${prefix}.fastq" : prefix
     def key_file = ''
@@ -34,14 +34,14 @@ process SRATOOLS_FASTERQDUMP {
     export NCBI_SETTINGS="\$PWD/${ncbi_settings}"
 
     fasterq-dump \\
-        $args \\
+        $fasterqdump_args \\
         --threads $task.cpus \\
         --outfile $outfile \\
         ${key_file} \\
         ${sra}
 
     pigz \\
-        $args2 \\
+        $pigz_args \\
         --no-name \\
         --processes $task.cpus \\
         *.fastq

--- a/modules/nf-core/sratools/fasterqdump/nextflow.config
+++ b/modules/nf-core/sratools/fasterqdump/nextflow.config
@@ -1,6 +1,5 @@
 process {
     withName: SRATOOLS_FASTERQDUMP {
-        ext.args = '--split-files --include-technical'
         publishDir = [
             path: { "${params.outdir}/fastq" },
             mode: params.publish_dir_mode,

--- a/modules/nf-core/sratools/fasterqdump/tests/nextflow.config
+++ b/modules/nf-core/sratools/fasterqdump/tests/nextflow.config
@@ -1,5 +1,0 @@
-process {
-    withName: SRATOOLS_FASTERQDUMP {
-        ext.args = ''
-    }
-}

--- a/nextflow.config
+++ b/nextflow.config
@@ -19,6 +19,11 @@ params {
     skip_fastq_download         = false
     dbgap_key                   = null
 
+    aspera_cli_args             = '-QT -l 300m -P33001'
+    sra_fastq_ftp_args          = '-t 5 -nv -c -T 60'
+    sratools_fasterqdump_args   = ''
+    sratools_pigz_args          = ''
+
     // Boilerplate options
     outdir                     = null
     publish_dir_mode           = 'copy'

--- a/subworkflows/nf-core/fastq_download_prefetch_fasterqdump_sratools/main.nf
+++ b/subworkflows/nf-core/fastq_download_prefetch_fasterqdump_sratools/main.nf
@@ -30,7 +30,13 @@ workflow FASTQ_DOWNLOAD_PREFETCH_FASTERQDUMP_SRATOOLS {
     //
     // Convert the SRA format into one or more compressed FASTQ files.
     //
-    SRATOOLS_FASTERQDUMP ( SRATOOLS_PREFETCH.out.sra, ch_ncbi_settings, ch_dbgap_key )
+    SRATOOLS_FASTERQDUMP (
+        SRATOOLS_PREFETCH.out.sra,
+        ch_ncbi_settings,
+        ch_dbgap_key,
+        params.sratools_fasterqdump_args ?: '',
+        params.sratools_pigz_args ?: ''
+    )
     ch_versions = ch_versions.mix(SRATOOLS_FASTERQDUMP.out.versions.first())
 
     emit:

--- a/workflows/sra/main.nf
+++ b/workflows/sra/main.nf
@@ -93,7 +93,8 @@ workflow SRA {
         // MODULE: If FTP link is provided in run information then download FastQ directly via FTP and validate with md5sums
         //
         SRA_FASTQ_FTP (
-            ch_sra_reads.ftp
+            ch_sra_reads.ftp,
+            params.sra_fastq_ftp_args ?: ''
         )
         ch_versions = ch_versions.mix(SRA_FASTQ_FTP.out.versions.first())
 
@@ -111,7 +112,8 @@ workflow SRA {
         //
         ASPERA_CLI (
             ch_sra_reads.aspera,
-            'era-fasp'
+            'era-fasp',
+            params.aspera_cli_args ?: ''
         )
         ch_versions = ch_versions.mix(ASPERA_CLI.out.versions.first())
 


### PR DESCRIPTION
See https://github.com/nextflow-io/nextflow/pull/4510#issuecomment-2071409697

tl;dr -- instead of implementing module config for the sole purpose of using `ext` as a shortcut to inject process inputs, let's just make them process inputs and control them with pipeline params as needed.

An interesting case with fetchngs is that the default args for `SRATOOLS_FASTERQDUMP` are overwritten by the subworkflow that uses it. For now I just left the default args in a comment, but it could also be hardcoded in the script body as a fallback value. Long term, it could be a default value with the declared input (as I have commented), likely as part of https://github.com/nextflow-io/nextflow/pull/4553 .

Between this refactor and replacing `publishDir` with the workflow publish DSL, we wouldn't need the module config at all, at least for the use cases we have gathered so far.