### PR TITLE
Use csv.reader to fix stray quote and comma handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Thank you to everyone else that has contributed by reporting bugs, enhancements 
 - [PR #378](https://github.com/nf-core/fetchngs/pull/378) - Update nf-core modules and subworkflows
 - [PR #379](https://github.com/nf-core/fetchngs/pull/379) - Replace SRA_TO_SAMPLESHEET process with CHANNEL_SRA_CREATE_CSV subworkflow using channel manipulation
 - [PR #379](https://github.com/nf-core/fetchngs/pull/379) - Strict syntax improvements
+- [PR #382](https://github.com/nf-core/fetchngs/pull/382) - Use csv.reader to fix stray quote and comma handling in multiqc_mappings_config (#375)
 
 ### Software dependencies
 

--- a/bin/multiqc_mappings_config.py
+++ b/bin/multiqc_mappings_config.py
@@ -3,12 +3,19 @@
 import csv
 import sys
 
-with open(sys.argv[1], "r") as fin, open(sys.argv[2], "w") as fout:
-    header = next(csv.reader(fin))
+with (
+    open(sys.argv[1], "r", newline="") as fin,
+    open(sys.argv[2], "w", newline="") as fout,
+):
+    reader = csv.reader(fin)
+    try:
+        header = next(reader)
+    except StopIteration:
+        sys.exit(0)
     config = "sample_names_rename_buttons:\n"
-    config += "\n".join(["  - " + x.strip('"') for x in header])
+    config += "\n".join(["  - " + x for x in header])
     config += "\nsample_names_rename:\n"
     rename = []
-    for row in csv.reader(fin):
+    for row in reader:
         rename.append(f"  - [{', '.join(row)}]")
     fout.write(config + "\n".join(sorted(rename)) + "\n")

--- a/bin/multiqc_mappings_config.py
+++ b/bin/multiqc_mappings_config.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python
 
+import csv
 import sys
 
 with open(sys.argv[1], "r") as fin, open(sys.argv[2], "w") as fout:
-    header = fin.readline().split(",")
+    header = next(csv.reader(fin))
     config = "sample_names_rename_buttons:\n"
     config += "\n".join(["  - " + x.strip('"') for x in header])
-    config += "sample_names_rename:\n"
+    config += "\nsample_names_rename:\n"
     rename = []
-    for line in fin:
-        rename.append(f"  - [{', '.join(line.strip().split(','))}]")
+    for row in csv.reader(fin):
+        rename.append(f"  - [{', '.join(row)}]")
     fout.write(config + "\n".join(sorted(rename)) + "\n")

--- a/modules/local/multiqc_mappings_config/tests/main.nf.test.snap
+++ b/modules/local/multiqc_mappings_config/tests/main.nf.test.snap
@@ -3,7 +3,7 @@
         "content": [
             {
                 "0": [
-                    "multiqc_config.yml:md5,7f3cb10fff83ba9eb3e8fa6862d1290a"
+                    "multiqc_config.yml:md5,2f0a31cabbe56da644d42e9e682a910e"
                 ],
                 "1": [
                     [
@@ -20,14 +20,14 @@
                     ]
                 ],
                 "yml": [
-                    "multiqc_config.yml:md5,7f3cb10fff83ba9eb3e8fa6862d1290a"
+                    "multiqc_config.yml:md5,2f0a31cabbe56da644d42e9e682a910e"
                 ]
             }
         ],
-        "timestamp": "2026-05-06T16:00:30.170721088",
+        "timestamp": "2026-08-13T14:10:23.983001827",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.4"
         }
     }
 }

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -129,11 +129,11 @@
                 "SRX9626017_SRR13191702_1.fastq.gz.md5:md5,055a6916ec9ee478e453d50651f87997",
                 "SRX9626017_SRR13191702_2.fastq.gz.md5:md5,c30ac785f8d80ec563fabf604d8bf945",
                 "id_mappings.csv:md5,33c5e095dbbb15def4e3b402eba6ade2",
-                "multiqc_config.yml:md5,bb99e81ddd360988338c10ecbdbce65a"
+                "multiqc_config.yml:md5,4c1962b5345d05b9fedd1eeee943aa44"
             ],
             "samplesheet.csv:md5,f7a9fefa9f4f4c57ffe3228c91ca28e4"
         ],
-        "timestamp": "2026-08-10T14:42:52.349537526",
+        "timestamp": "2026-08-13T14:23:24.813510759",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.4"

--- a/workflows/tests/main.nf.test.snap
+++ b/workflows/tests/main.nf.test.snap
@@ -6,7 +6,7 @@
                 "id_mappings.csv:md5,3e41ce6ab19feb76f2b20fa77a910ad3"
             ],
             [
-                "multiqc_config.yml:md5,1ac06bb95b503703430e74660bbdd768"
+                "multiqc_config.yml:md5,0f585277bfcae95ea182dcc9928f9243"
             ],
             [
                 [
@@ -148,7 +148,7 @@
                 }
             }
         ],
-        "timestamp": "2026-08-10T15:41:22.8196589",
+        "timestamp": "2026-08-13T14:25:56.266968939",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.4"

--- a/workflows/tests/sra_custom_ena_metadata_fields.nf.test.snap
+++ b/workflows/tests/sra_custom_ena_metadata_fields.nf.test.snap
@@ -6,7 +6,7 @@
                 "id_mappings.csv:md5,7345715e7db0a160efb8dd3be9ce58ac"
             ],
             [
-                "multiqc_config.yml:md5,3b70bc9658eab4ba2f4ec98cb749ac9d"
+                "multiqc_config.yml:md5,613f626037974b84c1dc1adca5866691"
             ],
             [
                 [
@@ -70,7 +70,7 @@
                 }
             }
         ],
-        "timestamp": "2026-08-10T13:27:41.172940253",
+        "timestamp": "2026-08-13T14:26:04.869488801",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.4"

--- a/workflows/tests/sra_download_method_aspera.nf.test.snap
+++ b/workflows/tests/sra_download_method_aspera.nf.test.snap
@@ -6,7 +6,7 @@
                 "id_mappings.csv:md5,3e41ce6ab19feb76f2b20fa77a910ad3"
             ],
             [
-                "multiqc_config.yml:md5,1ac06bb95b503703430e74660bbdd768"
+                "multiqc_config.yml:md5,0f585277bfcae95ea182dcc9928f9243"
             ],
             [
                 [
@@ -148,7 +148,7 @@
                 }
             }
         ],
-        "timestamp": "2026-08-10T13:28:39.763135849",
+        "timestamp": "2026-08-13T14:26:41.875947067",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.4"

--- a/workflows/tests/sra_download_method_fastqdl.nf.test.snap
+++ b/workflows/tests/sra_download_method_fastqdl.nf.test.snap
@@ -6,7 +6,7 @@
                 "id_mappings.csv:md5,3e41ce6ab19feb76f2b20fa77a910ad3"
             ],
             [
-                "multiqc_config.yml:md5,1ac06bb95b503703430e74660bbdd768"
+                "multiqc_config.yml:md5,0f585277bfcae95ea182dcc9928f9243"
             ],
             [
                 [
@@ -148,7 +148,7 @@
                 }
             }
         ],
-        "timestamp": "2026-08-10T13:29:40.97612474",
+        "timestamp": "2026-08-13T14:26:52.62902407",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.4"

--- a/workflows/tests/sra_download_method_sratools.nf.test.snap
+++ b/workflows/tests/sra_download_method_sratools.nf.test.snap
@@ -6,7 +6,7 @@
                 "id_mappings.csv:md5,3e41ce6ab19feb76f2b20fa77a910ad3"
             ],
             [
-                "multiqc_config.yml:md5,1ac06bb95b503703430e74660bbdd768"
+                "multiqc_config.yml:md5,0f585277bfcae95ea182dcc9928f9243"
             ],
             [
                 [
@@ -156,7 +156,7 @@
                 }
             }
         ],
-        "timestamp": "2026-08-10T14:50:49.11653117",
+        "timestamp": "2026-08-13T14:27:09.881255744",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.4"

--- a/workflows/tests/sra_nf_core_pipeline_atacseq.nf.test.snap
+++ b/workflows/tests/sra_nf_core_pipeline_atacseq.nf.test.snap
@@ -6,7 +6,7 @@
                 "id_mappings.csv:md5,3e41ce6ab19feb76f2b20fa77a910ad3"
             ],
             [
-                "multiqc_config.yml:md5,1ac06bb95b503703430e74660bbdd768"
+                "multiqc_config.yml:md5,0f585277bfcae95ea182dcc9928f9243"
             ],
             [
                 [
@@ -148,7 +148,7 @@
                 }
             }
         ],
-        "timestamp": "2026-08-10T13:31:02.330793126",
+        "timestamp": "2026-08-13T14:28:20.708690197",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.4"

--- a/workflows/tests/sra_nf_core_pipeline_rnaseq.nf.test.snap
+++ b/workflows/tests/sra_nf_core_pipeline_rnaseq.nf.test.snap
@@ -6,7 +6,7 @@
                 "id_mappings.csv:md5,3e41ce6ab19feb76f2b20fa77a910ad3"
             ],
             [
-                "multiqc_config.yml:md5,1ac06bb95b503703430e74660bbdd768"
+                "multiqc_config.yml:md5,0f585277bfcae95ea182dcc9928f9243"
             ],
             [
                 [
@@ -148,7 +148,7 @@
                 }
             }
         ],
-        "timestamp": "2026-08-10T13:31:19.683441235",
+        "timestamp": "2026-08-13T14:28:29.637752244",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.4"

--- a/workflows/tests/sra_nf_core_pipeline_taxprofiler.nf.test.snap
+++ b/workflows/tests/sra_nf_core_pipeline_taxprofiler.nf.test.snap
@@ -6,7 +6,7 @@
                 "id_mappings.csv:md5,3e41ce6ab19feb76f2b20fa77a910ad3"
             ],
             [
-                "multiqc_config.yml:md5,1ac06bb95b503703430e74660bbdd768"
+                "multiqc_config.yml:md5,0f585277bfcae95ea182dcc9928f9243"
             ],
             [
                 [
@@ -148,7 +148,7 @@
                 }
             }
         ],
-        "timestamp": "2026-08-10T13:31:33.386710659",
+        "timestamp": "2026-08-13T14:28:38.892361998",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.4"

--- a/workflows/tests/sra_nf_core_pipeline_viralrecon.nf.test.snap
+++ b/workflows/tests/sra_nf_core_pipeline_viralrecon.nf.test.snap
@@ -6,7 +6,7 @@
                 "id_mappings.csv:md5,3e41ce6ab19feb76f2b20fa77a910ad3"
             ],
             [
-                "multiqc_config.yml:md5,1ac06bb95b503703430e74660bbdd768"
+                "multiqc_config.yml:md5,0f585277bfcae95ea182dcc9928f9243"
             ],
             [
                 [
@@ -148,7 +148,7 @@
                 }
             }
         ],
-        "timestamp": "2026-08-10T13:31:47.461053544",
+        "timestamp": "2026-08-13T14:28:48.081638625",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.4"

--- a/workflows/tests/sra_skip_fastq_download.nf.test.snap
+++ b/workflows/tests/sra_skip_fastq_download.nf.test.snap
@@ -6,7 +6,7 @@
                 "id_mappings.csv:md5,3e41ce6ab19feb76f2b20fa77a910ad3"
             ],
             [
-                "multiqc_config.yml:md5,1ac06bb95b503703430e74660bbdd768"
+                "multiqc_config.yml:md5,0f585277bfcae95ea182dcc9928f9243"
             ],
             [
                 [
@@ -145,7 +145,7 @@
                 }
             }
         ],
-        "timestamp": "2026-08-10T13:32:00.423023774",
+        "timestamp": "2026-08-13T14:28:56.478884279",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.4"


### PR DESCRIPTION
Fixes #375

Use csv.reader instead of naive split to fix:
- Stray quote on last header field due to trailing newline
- Fields containing commas being split incorrectly

## CHANGES

- snapshots updated due to removing a trailing double quotes

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] CHANGELOG.md has been updated

Generated by opencode
Verfified by @maxulysse