### PR TITLE
Add ampliseq pipeline support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Thank you to everyone else that has contributed by reporting bugs, enhancements 
 - [PR #378](https://github.com/nf-core/fetchngs/pull/378) - Update nf-core modules and subworkflows
 - [PR #379](https://github.com/nf-core/fetchngs/pull/379) - Replace SRA_TO_SAMPLESHEET process with CHANNEL_SRA_CREATE_CSV subworkflow using channel manipulation
 - [PR #379](https://github.com/nf-core/fetchngs/pull/379) - Strict syntax improvements
+- Add ampliseq pipeline support
 
 ### Software dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ Thank you to everyone else that has contributed by reporting bugs, enhancements 
 - [PR #378](https://github.com/nf-core/fetchngs/pull/378) - Update nf-core modules and subworkflows
 - [PR #379](https://github.com/nf-core/fetchngs/pull/379) - Replace SRA_TO_SAMPLESHEET process with CHANNEL_SRA_CREATE_CSV subworkflow using channel manipulation
 - [PR #379](https://github.com/nf-core/fetchngs/pull/379) - Strict syntax improvements
-- Add ampliseq pipeline support
+- [PR #383](https://github.com/nf-core/fetchngs/pull/383) - Add ampliseq pipeline support
 
 ### Software dependencies
 

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -38,7 +38,7 @@
                     "type": "string",
                     "fa_icon": "fab fa-apple",
                     "description": "Name of supported nf-core pipeline e.g. 'rnaseq'. A samplesheet for direct use with the pipeline will be created with the appropriate columns.",
-                    "enum": ["rnaseq", "atacseq", "viralrecon", "taxprofiler"]
+                    "enum": ["ampliseq", "atacseq", "rnaseq", "taxprofiler", "viralrecon"]
                 },
                 "nf_core_rnaseq_strandedness": {
                     "type": "string",

--- a/subworkflows/local/channel_sra_create_csv/main.nf
+++ b/subworkflows/local/channel_sra_create_csv/main.nf
@@ -46,6 +46,7 @@ workflow CHANNEL_SRA_CREATE_CSV {
 
 def buildPipelineMap(meta, pipeline, strandedness) {
     def pipeline_extras = [
+        ampliseq: [run: ''],
         atacseq: [replicate: 1],
         rnaseq: [strandedness: strandedness],
         taxprofiler: [fasta: ''],

--- a/workflows/tests/sra_nf_core_pipeline_ampliseq.nf.test
+++ b/workflows/tests/sra_nf_core_pipeline_ampliseq.nf.test
@@ -1,0 +1,59 @@
+nextflow_workflow {
+
+    name "Test workflow: workflows/fetchngs.nf"
+    script "../fetchngs.nf"
+    workflow "FETCHNGS"
+    tag "SRA_NF_CORE_PIPELINE_AMPLISEQ"
+
+    // Dependencies
+    tag "SRA_IDS_TO_RUNINFO"
+    tag "SRA_RUNINFO_TO_FTP"
+    tag "SRA_FASTQ_FTP"
+    tag "SRA_TO_SAMPLESHEET"
+    tag "MULTIQC_MAPPINGS_CONFIG"
+
+    test("Parameters: --nf_core_pipeline ampliseq") {
+
+        when {
+            workflow {
+                """
+                input[0] = channel.of("DRX026011", "ERX1234253", "SRX6725035")
+                input[1] = "${outputDir}"
+                input[2] = []
+                input[3] = 'ftp'
+                input[4] = ''
+                input[5] = 'ampliseq'
+                input[6] = 'auto'
+                input[7] = 'experiment_accession,run_accession,sample_accession,experiment_alias,run_alias,sample_alias,experiment_title,sample_title,sample_description'
+                input[8] = false
+                """
+            }
+        }
+
+        then {
+            // csv_file: Just the samplesheet
+            def csv_file = path(outputDir + '/samplesheet/samplesheet.csv').csv()
+
+            // Sanitize sra_metadata to remove unstable output directory paths
+            def sra_metadata = workflow.out.sra_metadata.collect { meta ->
+                assert meta instanceof Map
+                def fastq1 = meta.fastq_1 ? (meta.fastq_1 instanceof List ? path(meta.fastq_1[0]).fileName.toString() : path(meta.fastq_1).fileName.toString()) : ''
+                def fastq2 = meta.fastq_2 ? (meta.fastq_2 instanceof List ? path(meta.fastq_2[0]).fileName.toString() : path(meta.fastq_2).fileName.toString()) : ''
+                return [meta + [fastq_1: fastq1] + [fastq_2: fastq2]]
+            }
+
+            assert workflow.success
+            assertAll(
+                { assert snapshot(
+                    // Samplesheet
+                    "samplesheet.csv:md5," + csv_file.sort().table.collect { row -> [row.getString("sample"), row.getString("fastq_1").replaceAll(outputDir, ""), row.getString("fastq_2").replaceAll(outputDir, "")].join(",") }.join("\n").md5(),
+                    workflow.out.mappings,
+                    workflow.out.sample_mappings,
+                    sra_metadata,
+                    // pipeline versions.yml file for multiqc from which Nextflow version is removed because we test pipelines on multiple Nextflow versions
+                    removeFromYamlMap("${outputDir}/pipeline_info/nf_core_fetchngs_software_versions.yml", "Workflow"),
+                ).match() }
+            )
+        }
+    }
+}

--- a/workflows/tests/sra_nf_core_pipeline_ampliseq.nf.test.snap
+++ b/workflows/tests/sra_nf_core_pipeline_ampliseq.nf.test.snap
@@ -1,0 +1,157 @@
+{
+    "Parameters: --nf_core_pipeline ampliseq": {
+        "content": [
+            "samplesheet.csv:md5,e457eb1e61c4f04181127cea006de9ca",
+            [
+                "id_mappings.csv:md5,3e41ce6ab19feb76f2b20fa77a910ad3"
+            ],
+            [
+                "multiqc_config.yml:md5,1ac06bb95b503703430e74660bbdd768"
+            ],
+            [
+                [
+                    {
+                        "base_count": "194930",
+                        "experiment_accession": "DRX026011",
+                        "experiment_alias": "DRX026011",
+                        "experiment_title": "Illumina HiSeq 2500 paired end sequencing: Illumina HiSeq 2500 paired end sequencing of SAMD00024405",
+                        "fastq_1": "DRX026011_DRR028935_1.fastq.gz",
+                        "fastq_2": "DRX026011_DRR028935_2.fastq.gz",
+                        "fastq_aspera": "fasp.sra.ebi.ac.uk:/vol1/fastq/DRR028/DRR028935/DRR028935_1.fastq.gz;fasp.sra.ebi.ac.uk:/vol1/fastq/DRR028/DRR028935/DRR028935_2.fastq.gz",
+                        "fastq_bytes": "60275;61610",
+                        "fastq_ftp": "ftp.sra.ebi.ac.uk/vol1/fastq/DRR028/DRR028935/DRR028935_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/DRR028/DRR028935/DRR028935_2.fastq.gz",
+                        "fastq_galaxy": "ftp.sra.ebi.ac.uk/vol1/fastq/DRR028/DRR028935/DRR028935_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/DRR028/DRR028935/DRR028935_2.fastq.gz",
+                        "fastq_md5": "cc01df82a9354bb6b3be93483b20c35a;941c9998d746416dad53c94c480ddf30",
+                        "id": "DRX026011_DRR028935",
+                        "instrument_model": "Illumina HiSeq 2500",
+                        "instrument_platform": "ILLUMINA",
+                        "library_layout": "PAIRED",
+                        "library_name": "day0_BbSQE-I",
+                        "library_selection": "cDNA",
+                        "library_source": "TRANSCRIPTOMIC",
+                        "library_strategy": "RNA-Seq",
+                        "md5_1": "cc01df82a9354bb6b3be93483b20c35a",
+                        "md5_2": "941c9998d746416dad53c94c480ddf30",
+                        "read_count": "965",
+                        "run_accession": "DRR028935",
+                        "run_alias": "DRR028935",
+                        "sample_accession": "SAMD00024405",
+                        "sample_alias": "SAMD00024405",
+                        "sample_description": "Liquid culture",
+                        "sample_title": "Botryococcus braunii Showa at day 0 after inoculation into fresh culture medium",
+                        "scientific_name": "Botryococcus braunii Showa",
+                        "secondary_sample_accession": "DRS019431",
+                        "secondary_study_accession": "DRP002616",
+                        "single_end": false,
+                        "study_accession": "PRJDB3420",
+                        "study_alias": "DRP002616",
+                        "study_title": "Liquid culture of Botryococcus braunii, race B, Showa",
+                        "submission_accession": "DRA002949",
+                        "tax_id": "1202541"
+                    }
+                ],
+                [
+                    {
+                        "base_count": "1996273",
+                        "experiment_accession": "SRX6725035",
+                        "experiment_alias": "Emb289P1_bin131",
+                        "experiment_title": "Illumina HiSeq 2500 sequencing: Binning of metagenomic reads from the P1 gut compartment of Embiratermes neotenicus",
+                        "fastq_1": "SRX6725035_SRR9984183.fastq.gz",
+                        "fastq_2": "",
+                        "fastq_aspera": "fasp.sra.ebi.ac.uk:/vol1/fastq/SRR998/003/SRR9984183/SRR9984183.fastq.gz",
+                        "fastq_bytes": "605358",
+                        "fastq_ftp": "ftp.sra.ebi.ac.uk/vol1/fastq/SRR998/003/SRR9984183/SRR9984183.fastq.gz",
+                        "fastq_galaxy": "ftp.sra.ebi.ac.uk/vol1/fastq/SRR998/003/SRR9984183/SRR9984183.fastq.gz",
+                        "fastq_md5": "0b512d2dc31685983456bd56fd836544",
+                        "id": "SRX6725035_SRR9984183",
+                        "instrument_model": "Illumina HiSeq 2500",
+                        "instrument_platform": "ILLUMINA",
+                        "library_layout": "SINGLE",
+                        "library_name": "Emb289P1_bin131",
+                        "library_selection": "RANDOM",
+                        "library_source": "METAGENOMIC",
+                        "library_strategy": "WGS",
+                        "md5_1": "0b512d2dc31685983456bd56fd836544",
+                        "md5_2": "",
+                        "read_count": "58",
+                        "run_accession": "SRR9984183",
+                        "run_alias": "Emb289P1_bin131.fastq",
+                        "sample_accession": "SAMN12581720",
+                        "sample_alias": "Emb289P1_bin131",
+                        "sample_description": "Keywords: GSC:MIxS MIMAG:5.0",
+                        "sample_title": "MIMAG Metagenome-assembled Genome sample from Defluviitaleaceae bacterium",
+                        "scientific_name": "Defluviitaleaceae bacterium",
+                        "secondary_sample_accession": "SRS5277011",
+                        "secondary_study_accession": "SRP218535",
+                        "single_end": true,
+                        "study_accession": "PRJNA560329",
+                        "study_alias": "PRJNA560329",
+                        "study_title": "Phylogenomic analysis of 589 metagenome-assembled genomes encompassing all major prokaryotic lineages from the gut of higher termites",
+                        "submission_accession": "SRA942061",
+                        "tax_id": "2660712"
+                    }
+                ],
+                [
+                    {
+                        "base_count": "35658",
+                        "experiment_accession": "ERX1234253",
+                        "experiment_alias": "qiita_ptid_1263:10317.BLANK.93.3E.r22",
+                        "experiment_title": "Illumina HiSeq 2500 sequencing: qiita_ptid_1263:10317.BLANK.93.3E.r22",
+                        "fastq_1": "ERX1234253_ERR1160846.fastq.gz",
+                        "fastq_2": "",
+                        "fastq_aspera": "fasp.sra.ebi.ac.uk:/vol1/fastq/ERR116/006/ERR1160846/ERR1160846.fastq.gz",
+                        "fastq_bytes": "18077",
+                        "fastq_ftp": "ftp.sra.ebi.ac.uk/vol1/fastq/ERR116/006/ERR1160846/ERR1160846.fastq.gz",
+                        "fastq_galaxy": "ftp.sra.ebi.ac.uk/vol1/fastq/ERR116/006/ERR1160846/ERR1160846.fastq.gz",
+                        "fastq_md5": "5924f20ef547ebdfed7cad795bbab6e6",
+                        "id": "ERX1234253_ERR1160846",
+                        "instrument_model": "Illumina HiSeq 2500",
+                        "instrument_platform": "ILLUMINA",
+                        "library_layout": "SINGLE",
+                        "library_name": "10317.BLANK.93.3E.r22",
+                        "library_selection": "PCR",
+                        "library_source": "METAGENOMIC",
+                        "library_strategy": "AMPLICON",
+                        "md5_1": "5924f20ef547ebdfed7cad795bbab6e6",
+                        "md5_2": "",
+                        "read_count": "283",
+                        "run_accession": "ERR1160846",
+                        "run_alias": "qiita_ppdid_706:10317.BLANK.93.3E.r22",
+                        "sample_accession": "SAMEA3687214",
+                        "sample_alias": "qiita_sid_10317:10317.BLANK.93.3E.r22",
+                        "sample_description": "American Gut control",
+                        "sample_title": "10317.BLANK.93.3E.r22",
+                        "scientific_name": "metagenome",
+                        "secondary_sample_accession": "ERS994363",
+                        "secondary_study_accession": "ERP012803",
+                        "single_end": true,
+                        "study_accession": "PRJEB11419",
+                        "study_alias": "qiita_sid_10317",
+                        "study_title": "American Gut Project",
+                        "submission_accession": "ERA541392",
+                        "tax_id": "256318"
+                    }
+                ]
+            ],
+            {
+                "MULTIQC_MAPPINGS_CONFIG": {
+                    "python": "3.9.5"
+                },
+                "SRA_FASTQ_FTP": {
+                    "wget": "1.21.4"
+                },
+                "SRA_IDS_TO_RUNINFO": {
+                    "python": "3.9.5"
+                },
+                "SRA_RUNINFO_TO_FTP": {
+                    "python": "3.9.5"
+                }
+            }
+        ],
+        "timestamp": "2026-08-13T14:53:37.03746842",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.4"
+        }
+    }
+}

--- a/workflows/tests/sra_nf_core_pipeline_ampliseq.nf.test.snap
+++ b/workflows/tests/sra_nf_core_pipeline_ampliseq.nf.test.snap
@@ -6,7 +6,7 @@
                 "id_mappings.csv:md5,3e41ce6ab19feb76f2b20fa77a910ad3"
             ],
             [
-                "multiqc_config.yml:md5,1ac06bb95b503703430e74660bbdd768"
+                "multiqc_config.yml:md5,0f585277bfcae95ea182dcc9928f9243"
             ],
             [
                 [

--- a/workflows/tests/sra_nf_core_pipeline_ampliseq.nf.test.snap
+++ b/workflows/tests/sra_nf_core_pipeline_ampliseq.nf.test.snap
@@ -138,7 +138,7 @@
                     "python": "3.9.5"
                 },
                 "SRA_FASTQ_FTP": {
-                    "wget": "1.21.4"
+                    "wget": "1.25.0"
                 },
                 "SRA_IDS_TO_RUNINFO": {
                     "python": "3.9.5"


### PR DESCRIPTION
Adds ampliseq pipeline support to fetchngs.

Replace and close:
- #324
- #361 

## Changes

- Add ampliseq to nextflow_schema.json enum
- Add ampliseq to pipeline_extras map with run column
- Add test for ampliseq pipeline

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] CHANGELOG.md has been updated

Generated by opencode
Verified by @maxulysse